### PR TITLE
[init] swagger 설정

### DIFF
--- a/BE/promate/build.gradle
+++ b/BE/promate/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 }
 
 tasks.named('test') {

--- a/BE/promate/src/main/resources/application.yml
+++ b/BE/promate/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 8082
+
 spring:
   application:
     name: "promate"


### PR DESCRIPTION
### 📖 개요
API 문서 자동화 및 테스트 환경 구축을 위한 Swagger(SpringDoc) 설정

### ⚙️ 작업 내용
* **springdoc-openapi** 의존성 추가
* 포트 번호 번경: 기본 8080에서 8082로 변경

### 🔗 접속 경로
서버 실행 후 [http://localhost:8082/swagger-ui/index.html](http://localhost:8082/swagger-ui/index.html)