### PR TITLE
[refactor] BaseBoard 상속 구조 도입(회의록, 공지사항)

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/apply/entity/Apply.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/entity/Apply.java
@@ -2,6 +2,7 @@ package org.example.promate.domain.apply.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.example.promate.domain.apply.enums.Status;
 import org.example.promate.domain.recruit.entity.Recruit;
 import org.example.promate.domain.user.entity.User;
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name="apply")

--- a/BE/promate/src/main/java/org/example/promate/domain/project/entity/Member.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/entity/Member.java
@@ -3,9 +3,12 @@ package org.example.promate.domain.project.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.example.promate.domain.project.enums.Position;
 import org.example.promate.domain.user.entity.User;
-import org.example.promate.domain.workspace.entity.Post;
+import org.example.promate.domain.workspace.entity.BaseBoard;
+import org.example.promate.domain.workspace.entity.MeetingLog;
+import org.example.promate.domain.workspace.entity.Notice;
 import org.example.promate.domain.workspace.entity.TaskAssignee;
 import org.springframework.data.annotation.CreatedDate;
 
@@ -14,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Builder
+@SuperBuilder
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -50,5 +53,9 @@ public class Member {
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     @Builder.Default
-    private List<Post> posts = new ArrayList<>();
+    private List<MeetingLog> meetingLogs = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<Notice> notices = new ArrayList<>();
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/project/entity/Project.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/entity/Project.java
@@ -2,12 +2,11 @@ package org.example.promate.domain.project.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.example.promate.domain.project.enums.ProjectStatus;
 import org.example.promate.domain.recruit.entity.Recruit;
 import org.example.promate.domain.user.entity.User;
-import org.example.promate.domain.workspace.entity.Event;
-import org.example.promate.domain.workspace.entity.Post;
-import org.example.promate.domain.workspace.entity.Task;
+import org.example.promate.domain.workspace.entity.*;
 import org.example.promate.global.entity.BaseTimeEntity;
 
 import java.time.LocalDate;
@@ -15,7 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Builder
+@SuperBuilder
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -64,5 +63,9 @@ public class Project extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
     @Builder.Default
-    private List<Post> posts = new ArrayList<>();
+    private List<MeetingLog> meetingLogs = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<Notice> notices = new ArrayList<>();
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/entity/Recruit.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/entity/Recruit.java
@@ -2,6 +2,7 @@ package org.example.promate.domain.recruit.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.example.promate.domain.apply.entity.Apply;
 import org.example.promate.domain.project.entity.Project;
 import org.example.promate.domain.recruit.enums.Category;
@@ -15,7 +16,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name="recruit")

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/entity/RecruitWishlist.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/entity/RecruitWishlist.java
@@ -2,12 +2,13 @@ package org.example.promate.domain.recruit.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.example.promate.domain.user.entity.User;
 import org.example.promate.global.entity.BaseEntity;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "recruit_wishlist")

--- a/BE/promate/src/main/java/org/example/promate/domain/user/entity/User.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package org.example.promate.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.example.promate.domain.apply.entity.Apply;
 import org.example.promate.domain.project.entity.Member;
 import org.example.promate.domain.project.entity.Project;
@@ -15,7 +16,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name="users")

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/BaseBoard.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/BaseBoard.java
@@ -1,0 +1,19 @@
+package org.example.promate.domain.workspace.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.example.promate.global.entity.BaseEntity;
+
+@Getter
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access =  AccessLevel.PROTECTED)
+@SuperBuilder
+public class BaseBoard extends BaseEntity {
+    @Column(name="title", nullable = false)
+    private String title;
+
+    @Column(name="content", nullable = false)
+    private String content;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/Event.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/Event.java
@@ -2,13 +2,14 @@ package org.example.promate.domain.workspace.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.example.promate.domain.project.entity.Project;
 import org.example.promate.global.entity.BaseEntity;
 
 import java.time.LocalDate;
 
 @Entity
-@Builder
+@SuperBuilder
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/MeetingLog.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/MeetingLog.java
@@ -2,31 +2,20 @@ package org.example.promate.domain.workspace.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.example.promate.domain.project.entity.Member;
 import org.example.promate.domain.project.entity.Project;
-import org.example.promate.domain.workspace.enums.PostType;
-import org.example.promate.global.entity.BaseEntity;
 
 @Entity
-@Builder
 @Getter
+@SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name="post")
-public class Post extends BaseEntity {
+@Table(name="meeting_log")
+public class MeetingLog extends BaseBoard{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Column(name="type", nullable = false)
-    @Enumerated(EnumType.STRING)
-    private PostType type;
-
-    @Column(name="title", nullable = false)
-    private String title;
-
-    @Column(name="content", nullable = false)
-    private String content;
 
     //mapping
     @ManyToOne(fetch = FetchType.LAZY)

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/Notice.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/Notice.java
@@ -4,14 +4,15 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.example.promate.domain.project.entity.Member;
+import org.example.promate.domain.project.entity.Project;
 
 @Entity
-@SuperBuilder
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name="task_assignee")
-public class TaskAssignee {
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name="notice")
+public class Notice extends BaseBoard{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -22,6 +23,6 @@ public class TaskAssignee {
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="task_id")
-    private Task task;
+    @JoinColumn(name="project_id")
+    private Project project;
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/Task.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/Task.java
@@ -2,6 +2,7 @@ package org.example.promate.domain.workspace.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.example.promate.domain.project.entity.Project;
 import org.example.promate.domain.workspace.enums.TaskStatus;
 import org.example.promate.global.entity.BaseTimeEntity;
@@ -10,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Builder
+@SuperBuilder
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/enums/PostType.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/enums/PostType.java
@@ -1,6 +1,0 @@
-package org.example.promate.domain.workspace.enums;
-
-public enum PostType {
-    NOTICE, //공지사항
-    MEETING_LOG //회의록
-}

--- a/BE/promate/src/main/java/org/example/promate/global/entity/BaseEntity.java
+++ b/BE/promate/src/main/java/org/example/promate/global/entity/BaseEntity.java
@@ -6,7 +6,11 @@ package org.example.promate.global.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -14,6 +18,9 @@ import java.time.LocalDateTime;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class BaseEntity extends BaseTimeEntity{
 
     @Column(name="is_deleted", nullable = false)

--- a/BE/promate/src/main/java/org/example/promate/global/entity/BaseTimeEntity.java
+++ b/BE/promate/src/main/java/org/example/promate/global/entity/BaseTimeEntity.java
@@ -6,7 +6,11 @@ package org.example.promate.global.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -16,6 +20,9 @@ import java.time.LocalDateTime;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class BaseTimeEntity {
     @CreatedDate
     @Column(name="created_at", nullable = false, updatable = false)


### PR DESCRIPTION
### 📖 개요
게시판 도메인의 객체지향적 설계와 유연한 객체 생성을 위해 상속 구조를 도입하고 Lombok `@SuperBuilder`로 리팩토링 진행

### ⚙️ 작업 내용
* **상속 구조 전환**
  * 단일 엔티티 내 `type` 구분 방식에서 `BaseBoard`를 부모로 하는 계층형 구조로 변경
  * `Notice`, `MeetingLog` 등 도메인별 전용 엔티티로 분리
* **Lombok `@SuperBuilder` 적용**
  * 기존 `@Builder`의 한계를 극복하기 위해 부모-자식 클래스 모두에 `@SuperBuilder` 도입