### PR TITLE
[feat] 모집 게시글(Recruit) CRUD 기능 구현

### DIFF
--- a/BE/.idea/vcs.xml
+++ b/BE/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/BE/promate/build.gradle
+++ b/BE/promate/build.gradle
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     compileOnly 'org.projectlombok:lombok'

--- a/BE/promate/build.gradle
+++ b/BE/promate/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.3'
+    id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -27,7 +27,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/BE/promate/build.gradle
+++ b/BE/promate/build.gradle
@@ -36,7 +36,30 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-web-ui:2.8.13'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
+
+    // 1. Querydsl 라이브러리 (Jakarta 대응 버전)
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    // 2. Querydsl QClass 생성을 위한 APT 설정
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+
+    // 3. Spring Boot 4.0+ 필수 Jakarta API
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(querydslDir)
+}
+
+clean {
+    delete querydslDir
 }
 
 tasks.named('test') {

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/controller/ApplyController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/controller/ApplyController.java
@@ -1,0 +1,46 @@
+package org.example.promate.domain.apply.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.example.promate.domain.apply.dto.ApplyFormResponse;
+import org.example.promate.domain.apply.dto.ApplyRequest;
+import org.example.promate.domain.apply.dto.ApplyResponse;
+import org.example.promate.domain.apply.service.ApplyService;
+import org.example.promate.domain.recruit.dto.response.RecruitCreateResponse;
+import org.example.promate.global.ApiPayload.ApiResponse;
+import org.example.promate.global.ApiPayload.code.RecruitSuccessCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/recruitments/{recruitmentsId}")
+@RequiredArgsConstructor
+public class ApplyController {
+
+    private final ApplyService applyService;
+
+    @GetMapping("application-form")
+    public ResponseEntity<ApiResponse<ApplyFormResponse>> getApplyFormData(
+            @PathVariable Long recruitmentsId
+            //@AuthenticationPrincipal Long userId // 현재 로그인한 사용자 ID (Spring Security 가정)
+    ) {
+        ApplyFormResponse response = applyService.getApplyForm(recruitmentsId, 100L); //임시 userId를 100으로 가정
+
+        return ResponseEntity
+                .status(RecruitSuccessCode.APPLY_FORM_LOADED.getStatus())
+                .body(ApiResponse.onSuccess(RecruitSuccessCode.APPLY_FORM_LOADED, response));
+    }
+
+    @PostMapping("/apply")
+    public ResponseEntity<ApiResponse<ApplyResponse>> apply(
+            @RequestBody @Valid ApplyRequest applyRequest,
+            @PathVariable Long recruitmentsId
+            //@AuthenticationPrincipal Long userId
+    ) {
+        ApplyResponse response = applyService.submit(recruitmentsId, 100L, applyRequest);
+        return ResponseEntity
+                .status(RecruitSuccessCode.APPLY_FORM_SUBMITTED.getStatus())
+                .body(ApiResponse.onSuccess(RecruitSuccessCode.APPLY_FORM_SUBMITTED, response));
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/dto/ApplyFormResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/dto/ApplyFormResponse.java
@@ -1,0 +1,16 @@
+package org.example.promate.domain.apply.dto;
+
+import org.example.promate.domain.recruit.enums.Category;
+
+import java.util.List;
+
+public record ApplyFormResponse(
+        String recruitmentTitle,
+        List<PastProjectDto> myPastProjects
+) {
+    public static ApplyFormResponse of(String title, List<PastProjectDto> projects) {
+        return new ApplyFormResponse(title, projects);
+    }
+}
+
+

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/dto/ApplyRequest.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/dto/ApplyRequest.java
@@ -1,0 +1,11 @@
+package org.example.promate.domain.apply.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record ApplyRequest(
+        @NotBlank String preferredRole,
+        @NotBlank String introduction,
+        List<Long> selectedProjectIds
+) {}

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/dto/ApplyResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/dto/ApplyResponse.java
@@ -1,0 +1,20 @@
+package org.example.promate.domain.apply.dto;
+
+import org.example.promate.domain.apply.entity.Apply;
+import org.example.promate.domain.apply.enums.Status;
+
+import java.time.LocalDateTime;
+
+public record ApplyResponse(
+        Long applicationId,
+        Status status,
+        LocalDateTime appliedAt
+) {
+    public static ApplyResponse from(Apply application) {
+        return new ApplyResponse(
+                application.getId(),
+                application.getStatus(),
+                application.getCreatedAt()
+        );
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/dto/PastProjectDto.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/dto/PastProjectDto.java
@@ -1,0 +1,9 @@
+package org.example.promate.domain.apply.dto;
+
+import org.example.promate.domain.recruit.enums.Category;
+
+public record PastProjectDto(
+        Long projectId,
+        String title,
+        Category category
+) {}

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/entity/Apply.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/entity/Apply.java
@@ -6,10 +6,14 @@ import lombok.experimental.SuperBuilder;
 import org.example.promate.domain.apply.enums.Status;
 import org.example.promate.domain.recruit.entity.Recruit;
 import org.example.promate.domain.user.entity.User;
+import org.example.promate.global.entity.BaseEntity;
+import org.example.promate.global.entity.BaseTimeEntity;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -17,11 +21,13 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name="apply")
-@EntityListeners(AuditingEntityListener.class)
-public class Apply {
+public class Apply extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name="objective")
+    private String objective; //희망 직무 (팀 승인 절차에서 분별을 위한 메타데이터)
 
     @Column(name="pr_content")
     private String prContent;
@@ -29,10 +35,6 @@ public class Apply {
     @Column(name="status", nullable = false)
     @Enumerated(EnumType.STRING)
     private Status status;
-
-    @CreatedDate
-    @Column(name="created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
 
     //mapping
     @ManyToOne(fetch = FetchType.LAZY)
@@ -42,4 +44,9 @@ public class Apply {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id")
     private User user;
+
+    //매핑 클래스의 리스트를 추가
+    @OneToMany(mappedBy = "apply", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ApplyProject> applyProjects = new ArrayList<>();
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/entity/ApplyProject.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/entity/ApplyProject.java
@@ -1,0 +1,35 @@
+package org.example.promate.domain.apply.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.promate.domain.project.entity.Project;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApplyProject {
+
+
+    //지원서 1개는 여러 가지 프로젝트 포함 가능 / 프로젝트 1개는 여러 지원서에 채택 가능
+    //다대다 관계를 표현하기 위한 매핑 클래스임
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name= "apply_id")
+    private Apply apply;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @Builder
+    public ApplyProject(Apply apply, Project project) {
+        this.apply = apply;
+        this.project = project;
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/repository/ApplicationProjectRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/repository/ApplicationProjectRepository.java
@@ -1,0 +1,7 @@
+package org.example.promate.domain.apply.repository;
+
+import org.example.promate.domain.apply.entity.ApplyProject;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicationProjectRepository extends JpaRepository<ApplyProject, Long> {
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/repository/ApplyRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/repository/ApplyRepository.java
@@ -1,0 +1,16 @@
+package org.example.promate.domain.apply.repository;
+
+import org.example.promate.domain.apply.entity.Apply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplyRepository extends JpaRepository<Apply, Long> {
+
+    // 특정 사용자가 특정 모집글에 이미 지원했는지 여부 확인 (모집 게시글 컨트롤러에서 사용)
+    boolean existsByRecruitIdAndUserId(Long recruitId, Long userId);
+
+    // 특정 모집글에 지원한 총 지원자 수 계산 (모집 게시글 컨트롤러에서 사용)
+    int countByRecruitId(Long recruitId);
+
+    // 특정 모집글 중복 지원 방지
+    boolean existsByRecruitIdAndUserIdAndIsDeletedFalse(Long recruitId, Long userId);
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/service/ApplyService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/service/ApplyService.java
@@ -1,0 +1,79 @@
+package org.example.promate.domain.apply.service;
+import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.apply.dto.ApplyFormResponse;
+import org.example.promate.domain.apply.dto.ApplyRequest;
+import org.example.promate.domain.apply.dto.ApplyResponse;
+import org.example.promate.domain.apply.dto.PastProjectDto;
+import org.example.promate.domain.apply.entity.Apply;
+import org.example.promate.domain.apply.entity.ApplyProject;
+import org.example.promate.domain.apply.enums.Status;
+import org.example.promate.domain.apply.repository.ApplicationProjectRepository;
+import org.example.promate.domain.apply.repository.ApplyRepository;
+import org.example.promate.domain.project.entity.Project;
+import org.example.promate.domain.project.repository.ProjectRepository;
+import org.example.promate.domain.recruit.entity.Recruit;
+import org.example.promate.domain.recruit.repository.RecruitRepository;
+import org.example.promate.domain.user.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ApplyService {
+
+    private final ApplyRepository applyRepository;
+    private final ApplicationProjectRepository applyProjectRepository;
+    //private final UserRepository userRepository;
+    private final RecruitRepository recruitRepository;
+    private final ProjectRepository projectRepository; // 사용자의 과거 프로젝트 조회를 위함
+
+    public ApplyFormResponse getApplyForm(Long recruitmentId, Long userId) {
+        // 모집글 제목을 위한 조회 (Soft Delete 고려)
+        Recruit recruit = recruitRepository.findByIdAndIsDeletedFalse(recruitmentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        // 사용자의 과거 완료된 프로젝트 목록 조회
+        // ProMate에서 완료된 프로젝트(Category, Title) 정보를 DTO 형식으로 바로 리스트화
+        List<PastProjectDto> pastProjects = projectRepository.findCompletedProjectsByUserId(userId);
+
+        return ApplyFormResponse.of(recruit.getTitle(), pastProjects);
+    }
+
+
+    public ApplyResponse submit(Long recruitmentId, Long userId, ApplyRequest request) {
+        // 1.중복 지원 방지 검증
+        if (applyRepository.existsByRecruitIdAndUserIdAndIsDeletedFalse(recruitmentId, userId)) {
+            throw new IllegalArgumentException("이미 지원한 모집글입니다.");
+        }
+
+        // 2. 연관 엔티티 조회
+        Recruit recruit = recruitRepository.findById(recruitmentId)
+                .orElseThrow(() ->new IllegalArgumentException("존재하지 않는 게시글 입니다."));
+        //User user = userRepository.findById(userId).get();
+
+        // 3. 지원서 생성 및 저장
+        Apply application = Apply.builder()
+                //.user(user)
+                .recruit(recruit)
+                .objective(request.preferredRole())
+                .prContent(request.introduction())
+                .status(Status.PENDING)
+                .build();
+        applyRepository.save(application);
+
+        // 4. 선택한 프로젝트 이력 매핑 저장
+        if (request.selectedProjectIds() != null && !request.selectedProjectIds().isEmpty()) {
+            List<Project> projects = projectRepository.findAllById(request.selectedProjectIds());
+
+            List<ApplyProject> mappings = projects.stream()
+                    .map(p -> new ApplyProject(application, p))
+                    .toList();
+            applyProjectRepository.saveAll(mappings);
+        }
+
+        return ApplyResponse.from(application);
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/project/entity/Member.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/entity/Member.java
@@ -10,7 +10,9 @@ import org.example.promate.domain.workspace.entity.BaseBoard;
 import org.example.promate.domain.workspace.entity.MeetingLog;
 import org.example.promate.domain.workspace.entity.Notice;
 import org.example.promate.domain.workspace.entity.TaskAssignee;
+import org.example.promate.global.entity.BaseTimeEntity;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -21,8 +23,9 @@ import java.util.List;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+
 @Table(name="member")
-public class Member {
+public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,13 +33,9 @@ public class Member {
     @Column(name="role", nullable = false)
     private String role;
 
-    @Column(name="position", nullable = false)
+    @Column(name="member_position", nullable = false) //MySQL 예약어랑 겹쳐서 수정
     @Enumerated(EnumType.STRING)
     private Position position;
-
-    @CreatedDate
-    @Column(name="created_at", nullable = false)
-    private LocalDateTime createdAt;
 
     //mapping
     @ManyToOne(fetch = FetchType.LAZY)

--- a/BE/promate/src/main/java/org/example/promate/domain/project/entity/Project.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/entity/Project.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class Project extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @Column(name="title", nullable = false)
     private String title;

--- a/BE/promate/src/main/java/org/example/promate/domain/project/repository/ProjectRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package org.example.promate.domain.project.repository;
+
+import org.example.promate.domain.project.entity.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectRepositoryCustom {
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/project/repository/ProjectRepositoryCustom.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/repository/ProjectRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.example.promate.domain.project.repository;
+
+import org.example.promate.domain.apply.dto.PastProjectDto;
+
+import java.util.List;
+
+public interface ProjectRepositoryCustom {
+    List<PastProjectDto> findCompletedProjectsByUserId(Long userId);
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/project/repository/ProjectRepositoryImpl.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/repository/ProjectRepositoryImpl.java
@@ -1,0 +1,38 @@
+package org.example.promate.domain.project.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.apply.dto.PastProjectDto;
+import org.example.promate.domain.project.enums.ProjectStatus;
+
+import java.util.List;
+
+import static org.example.promate.domain.project.entity.QMember.member;
+import static org.example.promate.domain.project.entity.QProject.project;
+import static org.example.promate.domain.recruit.entity.QRecruit.recruit;
+
+@RequiredArgsConstructor
+
+public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<PastProjectDto> findCompletedProjectsByUserId(Long userId) {
+        return queryFactory
+                .select(Projections.constructor(PastProjectDto.class,
+                        project.id,
+                        project.title,
+                        project.recruit.category
+                ))
+                .from(project)
+                .join(project.recruit, recruit)
+                .join(project.members, member)
+                .where(
+                        member.user.id.eq(userId),
+                        project.status.eq(ProjectStatus.COMPLETED)
+                )
+                .fetch();
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/controller/RecruitController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/controller/RecruitController.java
@@ -1,0 +1,76 @@
+package org.example.promate.domain.recruit.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.recruit.dto.request.RecruitCreateRequest;
+import org.example.promate.domain.recruit.dto.request.RecruitUpdateRequest;
+import org.example.promate.domain.recruit.dto.response.RecruitCreateResponse;
+import org.example.promate.domain.recruit.dto.response.RecruitDetailResponse;
+import org.example.promate.domain.recruit.service.RecruitService;
+import org.example.promate.global.ApiPayload.ApiResponse;
+import org.example.promate.global.ApiPayload.code.GeneralSuccessCode;
+import org.example.promate.global.ApiPayload.code.RecruitSuccessCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@ResponseBody
+@RequiredArgsConstructor
+@RequestMapping("/recruitments")
+public class RecruitController {
+
+    private final RecruitService recruitService;
+    // TODO: User 도메인 병합 후 연동 예정
+    // Long userId = user.getId();
+    Long userId = 1L; // 테스트용 임시 ID
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<RecruitCreateResponse>> create(
+            @Valid @RequestBody RecruitCreateRequest request
+            //@AuthenticationPrincipal CustomUser user
+    ) {
+        RecruitCreateResponse response = recruitService.createRecruitment(request, userId);
+
+        return ResponseEntity
+                .status(RecruitSuccessCode.RECRUITMENT_CREATED.getStatus())
+                .body(ApiResponse.onSuccess(RecruitSuccessCode.RECRUITMENT_CREATED, response));
+    }
+
+    @GetMapping("/{recruitmentId}")
+    public ResponseEntity<ApiResponse<RecruitDetailResponse>> detail(
+            @PathVariable Long recruitmentId
+            //@AuthenticationPrincipal CustomUser user
+    ) {
+        RecruitDetailResponse response = recruitService.getRecruitmentDetail(recruitmentId,userId);
+
+        return ResponseEntity
+                .status(RecruitSuccessCode.RECRUITMENT_FOUND.getStatus())
+                .body(ApiResponse.onSuccess(RecruitSuccessCode.RECRUITMENT_FOUND, response));
+    }
+
+    @PutMapping("/{recruitmentId}")
+    public ResponseEntity<ApiResponse<Void>> update(
+            @PathVariable Long recruitmentId,
+            @Valid @RequestBody RecruitUpdateRequest request
+            //@AuthenticationPrincipal CustomUser user
+    ) {
+        recruitService.updateRecruitment(recruitmentId,request,userId);
+
+        return ResponseEntity
+                .status(RecruitSuccessCode.RECRUITMENT_UPDATED.getStatus())
+                .body(ApiResponse.onSuccess(RecruitSuccessCode.RECRUITMENT_UPDATED,null));
+    }
+
+    @DeleteMapping("/{recruitmentId}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @PathVariable Long recruitmentId
+            //@AuthenticationPrincipal CustomUser user
+    ) {
+        recruitService.deleteRecruitment(recruitmentId,userId);
+
+        return ResponseEntity
+                .status(RecruitSuccessCode.RECRUITMENT_DELETED.getStatus())
+                .body(ApiResponse.onSuccess(RecruitSuccessCode.RECRUITMENT_DELETED,null));
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/controller/RecruitController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/controller/RecruitController.java
@@ -3,13 +3,18 @@ package org.example.promate.domain.recruit.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.promate.domain.recruit.dto.request.RecruitCreateRequest;
+import org.example.promate.domain.recruit.dto.request.RecruitSearchCondition;
 import org.example.promate.domain.recruit.dto.request.RecruitUpdateRequest;
 import org.example.promate.domain.recruit.dto.response.RecruitCreateResponse;
 import org.example.promate.domain.recruit.dto.response.RecruitDetailResponse;
+import org.example.promate.domain.recruit.dto.response.RecruitPageResponse;
+import org.example.promate.domain.recruit.dto.response.RecruitResponse;
 import org.example.promate.domain.recruit.service.RecruitService;
 import org.example.promate.global.ApiPayload.ApiResponse;
-import org.example.promate.global.ApiPayload.code.GeneralSuccessCode;
 import org.example.promate.global.ApiPayload.code.RecruitSuccessCode;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -72,5 +77,17 @@ public class RecruitController {
         return ResponseEntity
                 .status(RecruitSuccessCode.RECRUITMENT_DELETED.getStatus())
                 .body(ApiResponse.onSuccess(RecruitSuccessCode.RECRUITMENT_DELETED,null));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<RecruitPageResponse<RecruitResponse>>> getRecruitList(
+            @ModelAttribute RecruitSearchCondition condition,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        RecruitPageResponse<RecruitResponse> response = recruitService.getRecruitments(condition, pageable);
+
+        return ResponseEntity
+                .status(RecruitSuccessCode.RECRUITMENT_FILTERED.getStatus())
+                .body(ApiResponse.onSuccess(RecruitSuccessCode.RECRUITMENT_FILTERED,response));
     }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/request/RecruitCreateRequest.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/request/RecruitCreateRequest.java
@@ -1,0 +1,19 @@
+package org.example.promate.domain.recruit.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import org.example.promate.domain.recruit.enums.Category;
+
+import java.time.LocalDateTime;
+
+public record RecruitCreateRequest(
+        @NotNull(message = "제목을 입력하세요")
+        String title,
+        @NotNull(message = "내용을 입력하세요")
+        String description,
+        @NotNull(message = "카테고리를 선택해주세요.")
+        Category category,
+        @Min(value = 1, message = "최소 1명 이상이어야 합니다")
+        int totalSlots,
+        LocalDateTime deadline
+){}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/request/RecruitSearchCondition.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/request/RecruitSearchCondition.java
@@ -1,0 +1,8 @@
+package org.example.promate.domain.recruit.dto.request;
+
+import org.example.promate.domain.recruit.enums.Category;
+
+public record RecruitSearchCondition (
+    String search,
+    Category category
+){}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/request/RecruitSearchCondition.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/request/RecruitSearchCondition.java
@@ -1,5 +1,4 @@
 package org.example.promate.domain.recruit.dto.request;
-
 import org.example.promate.domain.recruit.enums.Category;
 
 public record RecruitSearchCondition (

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/request/RecruitUpdateRequest.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/request/RecruitUpdateRequest.java
@@ -1,0 +1,14 @@
+package org.example.promate.domain.recruit.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.example.promate.domain.recruit.enums.RecruitStatus;
+
+public record RecruitUpdateRequest(
+        @NotBlank(message = "제목은 비워둘 수 없습니다.")
+        String title,
+        @NotBlank(message = "내용은 비워둘 수 없습니다.")
+        String content,
+        @NotNull(message = "상태값은 필수입니다.")
+        RecruitStatus status
+){}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitCreateResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitCreateResponse.java
@@ -1,0 +1,5 @@
+package org.example.promate.domain.recruit.dto.response;
+
+public record RecruitCreateResponse(
+      Long recruitmentId
+){}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitDetailResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitDetailResponse.java
@@ -1,0 +1,30 @@
+package org.example.promate.domain.recruit.dto.response;
+
+import lombok.Builder;
+import org.example.promate.domain.recruit.enums.Category;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record RecruitDetailResponse(
+        Long postId,
+        String title,
+        String content,
+        Category category,
+        String status,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime deadline,
+        AuthorDto author,
+        boolean isAuthor,
+        boolean hasApplied,
+        int applicantCount
+) {
+    //모집글(부모) - 작성자(자식) 상속관계 표현
+    public record AuthorDto(
+            Long memberId,
+            String nickname,
+            String profileImageUrl
+    ) {}
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitListResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitListResponse.java
@@ -1,0 +1,4 @@
+package org.example.promate.domain.recruit.dto.response;
+
+public class RecruitListResponse {
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitListResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitListResponse.java
@@ -1,4 +1,0 @@
-package org.example.promate.domain.recruit.dto.response;
-
-public class RecruitListResponse {
-}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitPageResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitPageResponse.java
@@ -1,0 +1,30 @@
+package org.example.promate.domain.recruit.dto.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record RecruitPageResponse<T>(
+        List<T> content,
+        PageInfo pageInfo
+) {
+    public static <T> RecruitPageResponse<T> of(Page<T> page) {
+        return new RecruitPageResponse<>(
+                page.getContent(),
+                new PageInfo(
+                        page.getNumber(),
+                        page.getSize(),
+                        page.getTotalElements(),
+                        page.getTotalPages(),
+                        page.isLast()
+                )
+        );
+    }
+    public record PageInfo(
+            int currentPage,
+            int pageSize,
+            long totalElements,
+            int totalPages,
+            boolean last
+    ) {}
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitResponse.java
@@ -1,0 +1,17 @@
+package org.example.promate.domain.recruit.dto.response;
+
+import org.example.promate.domain.recruit.enums.Category;
+import org.example.promate.domain.recruit.enums.RecruitStatus;
+
+import java.time.LocalDateTime;
+
+public record RecruitResponse(
+        Long recruitmentId,
+        String title,
+        Category category,
+        LocalDateTime createdAt,
+        LocalDateTime deadline,
+        RecruitStatus status,
+        int maxMember,
+        int currentMember
+) {}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/entity/Recruit.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/entity/Recruit.java
@@ -9,6 +9,7 @@ import org.example.promate.domain.recruit.enums.Category;
 import org.example.promate.domain.recruit.enums.RecruitStatus;
 import org.example.promate.domain.user.entity.User;
 import org.example.promate.global.entity.BaseEntity;
+import tools.jackson.core.ObjectReadContext;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -65,4 +66,14 @@ public class Recruit extends BaseEntity {
     @OneToMany(mappedBy = "recruit", fetch = FetchType.LAZY)
     @Builder.Default
     private List<Apply> applies = new ArrayList<>();
+
+    public void update(String title, String description, RecruitStatus status) {
+        this.title = title;
+        this.description = description;
+        this.status = status;
+    }
+
+    public void delete(){
+        super.performDelete();
+    }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/entity/Recruit.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/entity/Recruit.java
@@ -9,7 +9,6 @@ import org.example.promate.domain.recruit.enums.Category;
 import org.example.promate.domain.recruit.enums.RecruitStatus;
 import org.example.promate.domain.user.entity.User;
 import org.example.promate.global.entity.BaseEntity;
-import tools.jackson.core.ObjectReadContext;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepository.java
@@ -1,0 +1,31 @@
+package org.example.promate.domain.recruit.repository;
+
+import org.example.promate.domain.recruit.entity.Recruit;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RecruitRepository extends JpaRepository<Recruit, Long> {
+
+    /*
+     1. 삭제되지 않은 특정 모집글 상세 조회
+     Optional을 반환하여 Service 계층에서 .orElseThrow() 처리를 강제합니다.
+     */
+    Optional<Recruit> findByIdAndIsDeletedFalse(Long id);
+
+    /*
+     2. 삭제되지 않은 전체 모집글 페이징 조회
+     최신순 정렬 등은 Service에서 Pageable 객체를 통해 넘겨받습니다.
+     */
+    Page<Recruit> findAllByIsDeletedFalse(Pageable pageable);
+
+    /*
+     3.특정 작성자가 올린 삭제되지 않은 글 목록
+     */
+    Page<Recruit> findAllByUserIdAndIsDeletedFalse(Long userId, Pageable pageable);
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepository.java
@@ -10,8 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface RecruitRepository extends JpaRepository<Recruit, Long> {
-
+public interface RecruitRepository extends JpaRepository<Recruit, Long>, RecruitRepositoryCustom {
     /*
      1. 삭제되지 않은 특정 모집글 상세 조회
      Optional을 반환하여 Service 계층에서 .orElseThrow() 처리를 강제합니다.

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepositoryCustom.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepositoryCustom.java
@@ -1,0 +1,10 @@
+package org.example.promate.domain.recruit.repository;
+
+import org.example.promate.domain.recruit.dto.request.RecruitSearchCondition;
+import org.example.promate.domain.recruit.dto.response.RecruitResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface RecruitRepositoryCustom {
+    Page<RecruitResponse> searchRecruits(RecruitSearchCondition condition, Pageable pageable);
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepositoryImpl.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepositoryImpl.java
@@ -41,6 +41,7 @@ public class RecruitRepositoryImpl implements RecruitRepositoryCustom {
                 ))
                 .from(recruit)
                 .where(
+                        recruit.isDeleted.isFalse(),
                         containsSearch(condition.search()),
                         eqCategory(condition.category())
                 )

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepositoryImpl.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepositoryImpl.java
@@ -1,0 +1,78 @@
+package org.example.promate.domain.recruit.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.recruit.dto.request.RecruitSearchCondition;
+import org.example.promate.domain.recruit.dto.response.RecruitResponse;
+import org.example.promate.domain.recruit.enums.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static org.example.promate.domain.recruit.entity.QRecruit.recruit;
+
+@Repository
+@RequiredArgsConstructor
+public class RecruitRepositoryImpl implements RecruitRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<RecruitResponse> searchRecruits(RecruitSearchCondition condition, Pageable pageable) {
+
+        // 데이터 조회 쿼리
+        List<RecruitResponse> content = queryFactory
+                .select(Projections.constructor(RecruitResponse.class,
+                        recruit.id,
+                        recruit.title,
+                        recruit.category,
+                        recruit.createdAt,
+                        recruit.deadline,
+                        recruit.status,
+                        recruit.totalSlots,
+                        recruit.joinedCount
+                ))
+                .from(recruit)
+                .where(
+                        containsSearch(condition.search()),
+                        eqCategory(condition.category())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(recruit.createdAt.desc()) //기본값: 최신순
+                .fetch();
+
+        // 전체 카운트 쿼리
+        JPAQuery<Long> countQuery = queryFactory
+                .select(recruit.count())
+                .from(recruit)
+                .where(
+                        containsSearch(condition.search()),
+                        eqCategory(condition.category())
+                );
+
+        // Page 객체로 반환
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    // 제목 검색 (search 키워드가 포함되어 있는지)
+    private BooleanExpression containsSearch(String search) {
+        return StringUtils.hasText(search) ? recruit.title.containsIgnoreCase(search) : null;
+    }
+
+    //카테고리 필터링 (정확히 일치하는지)
+    private BooleanExpression eqCategory(Category category) {
+        if (category == null) {
+            return null;
+        }
+        // Enum 대 Enum 비교
+        return recruit.category.eq(category);
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
@@ -1,0 +1,98 @@
+package org.example.promate.domain.recruit.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.recruit.dto.request.RecruitCreateRequest;
+import org.example.promate.domain.recruit.dto.request.RecruitUpdateRequest;
+import org.example.promate.domain.recruit.dto.response.RecruitCreateResponse;
+import org.example.promate.domain.recruit.dto.response.RecruitDetailResponse;
+import org.example.promate.domain.recruit.entity.Recruit;
+import org.example.promate.domain.recruit.repository.RecruitRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecruitService {
+    private final RecruitRepository recruitRepository;
+    //private final UserRepository userRepository;
+    //private final ApplicationRepository applicationRepository; // 지원 내역 확인용
+
+    @Transactional
+    public RecruitCreateResponse createRecruitment(
+            RecruitCreateRequest request, Long userId)
+    {
+        // User writer = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다."));
+        Recruit recruit = Recruit.builder()
+                .title(request.title())
+                .description(request.description())
+                .category(request.category())
+                .totalSlots(request.totalSlots())
+                .deadline(request.deadline())
+                //.user(writer)
+                .build();
+
+        Recruit savedRecruit = recruitRepository.save(recruit);
+
+        return new RecruitCreateResponse(savedRecruit.getId());
+    }
+
+    public RecruitDetailResponse getRecruitmentDetail(Long recruitmentId, Long currentUserId) {
+        Recruit recruit = recruitRepository.findByIdAndIsDeletedFalse(recruitmentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        boolean isAuthor = recruit.getUser().getId().equals(currentUserId);
+        //지원 여부 및 지원자 수 계산 (Application 만들고 도입)
+        // boolean hasApplied = applicationRepository.existsByRecruitIdAndUserId(recruitmentId, currentUserId);
+        // int applicantCount = applicationRepository.countByRecruitId(recruitmentId);
+
+        // 임시 하드코딩 (아직 Application 도메인이 없으므로)
+        boolean hasApplied = false;
+        int applicantCount = 5;
+
+        return new RecruitDetailResponse(
+                recruit.getId(),
+                recruit.getTitle(),
+                recruit.getDescription(),
+                recruit.getCategory(),
+                "RECRUITING", // 임시 상태값
+                recruit.getCreatedAt(),
+                recruit.getUpdatedAt(),
+                recruit.getDeadline(),
+                new RecruitDetailResponse.AuthorDto(
+                        recruit.getUser().getId(),
+                        recruit.getUser().getName(),
+                        recruit.getUser().getProfileImageUrl()
+                ),
+                isAuthor,
+                hasApplied,
+                applicantCount
+        );
+    }
+
+    @Transactional
+    public void updateRecruitment(Long recruitmentId, RecruitUpdateRequest request, Long userId) {
+
+        Recruit recruit = recruitRepository.findByIdAndIsDeletedFalse(recruitmentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        if (!recruit.getUser().getId().equals(userId)) {
+            throw new SecurityException("수정 권한이 없습니다.");
+        }
+
+        recruit.update(request.title(), request.content(), request.status());
+    }
+
+    @Transactional
+    public void deleteRecruitment(Long recruitmentId, Long userId) {
+
+        Recruit recruit = recruitRepository.findByIdAndIsDeletedFalse(recruitmentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        if (!recruit.getUser().getId().equals(userId)) {
+            throw new SecurityException("삭제 권한이 없습니다.");
+        }
+
+        recruit.delete();
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
@@ -1,6 +1,7 @@
 package org.example.promate.domain.recruit.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.apply.repository.ApplyRepository;
 import org.example.promate.domain.recruit.dto.request.RecruitCreateRequest;
 import org.example.promate.domain.recruit.dto.request.RecruitSearchCondition;
 import org.example.promate.domain.recruit.dto.request.RecruitUpdateRequest;
@@ -19,9 +20,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RecruitService {
+
     private final RecruitRepository recruitRepository;
     //private final UserRepository userRepository;
-    //private final ApplicationRepository applicationRepository; // 지원 내역 확인용
+    private final ApplyRepository applyRepository; // 지원 내역 확인용
 
     @Transactional
     public RecruitCreateResponse createRecruitment(
@@ -47,13 +49,9 @@ public class RecruitService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
 
         boolean isAuthor = recruit.getUser().getId().equals(currentUserId);
-        //지원 여부 및 지원자 수 계산 (Application 만들고 도입)
-        // boolean hasApplied = applicationRepository.existsByRecruitIdAndUserId(recruitmentId, currentUserId);
-        // int applicantCount = applicationRepository.countByRecruitId(recruitmentId);
 
-        // 임시 하드코딩 (아직 Application 도메인이 없으므로)
-        boolean hasApplied = false;
-        int applicantCount = 5;
+        boolean hasApplied = applyRepository.existsByRecruitIdAndUserId(recruitmentId, currentUserId);
+        int applicantCount = applyRepository.countByRecruitId(recruitmentId);
 
         return new RecruitDetailResponse(
                 recruit.getId(),

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
@@ -2,11 +2,16 @@ package org.example.promate.domain.recruit.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.promate.domain.recruit.dto.request.RecruitCreateRequest;
+import org.example.promate.domain.recruit.dto.request.RecruitSearchCondition;
 import org.example.promate.domain.recruit.dto.request.RecruitUpdateRequest;
 import org.example.promate.domain.recruit.dto.response.RecruitCreateResponse;
 import org.example.promate.domain.recruit.dto.response.RecruitDetailResponse;
+import org.example.promate.domain.recruit.dto.response.RecruitPageResponse;
+import org.example.promate.domain.recruit.dto.response.RecruitResponse;
 import org.example.promate.domain.recruit.entity.Recruit;
 import org.example.promate.domain.recruit.repository.RecruitRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,7 +27,7 @@ public class RecruitService {
     public RecruitCreateResponse createRecruitment(
             RecruitCreateRequest request, Long userId)
     {
-        // User writer = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다."));
+        //User writer = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다."));
         Recruit recruit = Recruit.builder()
                 .title(request.title())
                 .description(request.description())
@@ -94,5 +99,12 @@ public class RecruitService {
         }
 
         recruit.delete();
+    }
+
+    public RecruitPageResponse<RecruitResponse> getRecruitments(RecruitSearchCondition condition, Pageable pageable) {
+
+        Page<RecruitResponse> resultPage = recruitRepository.searchRecruits(condition, pageable);
+
+        return RecruitPageResponse.of(resultPage);
     }
 }

--- a/BE/promate/src/main/java/org/example/promate/global/ApiPayload/code/RecruitSuccessCode.java
+++ b/BE/promate/src/main/java/org/example/promate/global/ApiPayload/code/RecruitSuccessCode.java
@@ -1,0 +1,19 @@
+package org.example.promate.global.ApiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum RecruitSuccessCode implements BaseSuccessCode{
+    RECRUITMENT_CREATED(HttpStatus.CREATED, "RECRUIT_S001", "팀 모집 게시글 발행을 성공했습니다."),
+    RECRUITMENT_FOUND(HttpStatus.OK, "RECRUIT_S002", "팀 모집글 상세 조회를 성공했습니다."),
+    RECRUITMENT_UPDATED(HttpStatus.OK, "RECRUIT_S003", "팀 모집글 수정을 성공했습니다 ."),
+    RECRUITMENT_DELETED(HttpStatus.NO_CONTENT, "RECRUIT_S004", "팀 모집글 삭제를 성공했습니다 .")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/BE/promate/src/main/java/org/example/promate/global/ApiPayload/code/RecruitSuccessCode.java
+++ b/BE/promate/src/main/java/org/example/promate/global/ApiPayload/code/RecruitSuccessCode.java
@@ -10,7 +10,8 @@ public enum RecruitSuccessCode implements BaseSuccessCode{
     RECRUITMENT_CREATED(HttpStatus.CREATED, "RECRUIT_S001", "팀 모집 게시글 발행을 성공했습니다."),
     RECRUITMENT_FOUND(HttpStatus.OK, "RECRUIT_S002", "팀 모집글 상세 조회를 성공했습니다."),
     RECRUITMENT_UPDATED(HttpStatus.OK, "RECRUIT_S003", "팀 모집글 수정을 성공했습니다 ."),
-    RECRUITMENT_DELETED(HttpStatus.NO_CONTENT, "RECRUIT_S004", "팀 모집글 삭제를 성공했습니다 .")
+    RECRUITMENT_DELETED(HttpStatus.NO_CONTENT, "RECRUIT_S004", "팀 모집글 삭제를 성공했습니다 ."),
+    RECRUITMENT_FILTERED(HttpStatus.NO_CONTENT, "RECRUIT_S005", "팀 모집글 필터링을 성공했습니다 .")
     ;
 
     private final HttpStatus status;

--- a/BE/promate/src/main/java/org/example/promate/global/ApiPayload/code/RecruitSuccessCode.java
+++ b/BE/promate/src/main/java/org/example/promate/global/ApiPayload/code/RecruitSuccessCode.java
@@ -11,7 +11,11 @@ public enum RecruitSuccessCode implements BaseSuccessCode{
     RECRUITMENT_FOUND(HttpStatus.OK, "RECRUIT_S002", "팀 모집글 상세 조회를 성공했습니다."),
     RECRUITMENT_UPDATED(HttpStatus.OK, "RECRUIT_S003", "팀 모집글 수정을 성공했습니다 ."),
     RECRUITMENT_DELETED(HttpStatus.NO_CONTENT, "RECRUIT_S004", "팀 모집글 삭제를 성공했습니다 ."),
-    RECRUITMENT_FILTERED(HttpStatus.NO_CONTENT, "RECRUIT_S005", "팀 모집글 필터링을 성공했습니다 .")
+    RECRUITMENT_FILTERED(HttpStatus.NO_CONTENT, "RECRUIT_S005", "팀 모집글 필터링을 성공했습니다 ."),
+
+
+    APPLY_FORM_LOADED(HttpStatus.OK, "RECRUIT_S006", "팀 지원글 작성 페이지 불러오기를 성공했습니다."),
+    APPLY_FORM_SUBMITTED(HttpStatus.OK, "RECRUIT_S007", "팀 지원글 발행을 성공했습니다.")
     ;
 
     private final HttpStatus status;

--- a/BE/promate/src/main/java/org/example/promate/global/config/QuerydslConfig.java
+++ b/BE/promate/src/main/java/org/example/promate/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package org.example.promate.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/global/entity/BaseEntity.java
+++ b/BE/promate/src/main/java/org/example/promate/global/entity/BaseEntity.java
@@ -28,4 +28,10 @@ public class BaseEntity extends BaseTimeEntity{
 
     @Column(name="deleted_at")
     private LocalDateTime deletedAt;
+
+    //자식 엔티티에서만 이 함수에 접근 가능하도록
+    protected void performDelete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/BE/promate/src/main/java/org/example/promate/global/entity/BaseTimeEntity.java
+++ b/BE/promate/src/main/java/org/example/promate/global/entity/BaseTimeEntity.java
@@ -25,10 +25,10 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class BaseTimeEntity {
     @CreatedDate
-    @Column(name="created_at", nullable = false, updatable = false)
+    @Column(name="created_at", nullable = false, updatable = false, columnDefinition = "datetime(6) DEFAULT NOW(6)")
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name="updated_at", nullable = false)
+    @Column(name="updated_at", nullable = false, columnDefinition = "datetime(6) DEFAULT NOW(6)")
     private LocalDateTime updatedAt;
 }

--- a/BE/promate/src/main/resources/application.yml
+++ b/BE/promate/src/main/resources/application.yml
@@ -20,3 +20,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+springdoc:
+  querydsl:
+    enabled: false
+  api-docs:
+    enabled: true


### PR DESCRIPTION
- Recruit 엔티티에 update/delete 함수 추가
- 게시글 생성, 상세 조회, 수정, 삭제(Soft Delete) API 구현
- 요청/응답 DTO 분리
- RecruitSuccessCode Enum 정의를 통한 도메인별 성공 응답 체계 규격화