### PR TITLE
[feat] 공통 - 메인 버튼 및 퍼센트 바 컴포넌트 구현

### DIFF
--- a/FE/src/components/MainButton/MainButton.css
+++ b/FE/src/components/MainButton/MainButton.css
@@ -38,3 +38,7 @@
   cursor: not-allowed;
   opacity: 0.7;
 }
+
+.main-btn.full-width {
+  width: 100%;
+}

--- a/FE/src/components/MainButton/MainButton.css
+++ b/FE/src/components/MainButton/MainButton.css
@@ -1,0 +1,40 @@
+.main-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+
+  height: 42px;
+  padding: 10px 25px;
+
+  border: none;
+  border-radius: 10px;
+
+  background-color: #FE9A57;
+  color: #ffffff;
+
+  font-size: 18px;
+  font-weight: 600;
+
+  cursor: pointer;
+  white-space: nowrap;
+
+  transition: background-color 0.2s ease;
+}
+
+/* hover */
+.main-btn:hover {
+  background-color: #e8894c;
+}
+
+/* active */
+.main-btn:active {
+  background-color: #d87c42;
+}
+
+/* disabled */
+.main-btn:disabled {
+  background-color: #d9d9d9;
+  cursor: not-allowed;
+  opacity: 0.7;
+}

--- a/FE/src/components/MainButton/MainButton.jsx
+++ b/FE/src/components/MainButton/MainButton.jsx
@@ -1,0 +1,22 @@
+import "./MainButton.css";
+
+function MainButton({
+  children,
+  onClick,
+  disabled = false,
+  type = "button",
+  size = "md",
+}) {
+  return (
+    <button
+      type={type}
+      className={`main-btn ${size}`}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default MainButton;

--- a/FE/src/components/MainButton/MainButton.jsx
+++ b/FE/src/components/MainButton/MainButton.jsx
@@ -6,11 +6,12 @@ function MainButton({
   disabled = false,
   type = "button",
   size = "md",
+  fullWidth = false,
 }) {
   return (
     <button
       type={type}
-      className={`main-btn ${size}`}
+      className={`main-btn ${size} ${fullWidth ? "full-width" : ""}`}
       onClick={onClick}
       disabled={disabled}
     >

--- a/FE/src/components/MainButton/MainButton.jsx
+++ b/FE/src/components/MainButton/MainButton.jsx
@@ -7,6 +7,7 @@ function MainButton({
   type = "button",
   size = "md",
   fullWidth = false,
+  ...props
 }) {
   return (
     <button
@@ -14,6 +15,7 @@ function MainButton({
       className={`main-btn ${size} ${fullWidth ? "full-width" : ""}`}
       onClick={onClick}
       disabled={disabled}
+      {...props}
     >
       {children}
     </button>

--- a/FE/src/components/ProgressBar/ProgressBar.css
+++ b/FE/src/components/ProgressBar/ProgressBar.css
@@ -1,0 +1,20 @@
+.progress-bar {
+  width: 100%;
+  max-width: 700px;
+
+  height: 8px;
+  background-color: #F1F1F1;
+
+  border: 1px solid #D9D9D9;
+  border-radius: 999px;
+
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background-color: #FE9A57;
+
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}

--- a/FE/src/components/ProgressBar/ProgressBar.jsx
+++ b/FE/src/components/ProgressBar/ProgressBar.jsx
@@ -1,11 +1,13 @@
 import "./ProgressBar.css";
 
 function ProgressBar({ percent = 0 }) {
+  const safePercent = Math.min(Math.max(percent, 0), 100);
+
   return (
     <div className="progress-bar">
       <div
         className="progress-fill"
-        style={{ width: `${percent}%` }}
+        style={{ width: `${safePercent}%` }}
       />
     </div>
   );

--- a/FE/src/components/ProgressBar/ProgressBar.jsx
+++ b/FE/src/components/ProgressBar/ProgressBar.jsx
@@ -1,0 +1,14 @@
+import "./ProgressBar.css";
+
+function ProgressBar({ percent = 0 }) {
+  return (
+    <div className="progress-bar">
+      <div
+        className="progress-fill"
+        style={{ width: `${percent}%` }}
+      />
+    </div>
+  );
+}
+
+export default ProgressBar;

--- a/FE/src/components/ProgressBar/ProgressBar.jsx
+++ b/FE/src/components/ProgressBar/ProgressBar.jsx
@@ -1,10 +1,10 @@
 import "./ProgressBar.css";
 
-function ProgressBar({ percent = 0 }) {
+function ProgressBar({ percent = 0, ...props }) {
   const safePercent = Math.min(Math.max(percent, 0), 100);
 
   return (
-    <div className="progress-bar">
+    <div className="progress-bar" {...props}>
       <div
         className="progress-fill"
         style={{ width: `${safePercent}%` }}


### PR DESCRIPTION
## 📌개요
공통 컴포넌트인 MainButton과 ProgressBar를 구현했습니다.

## ⚙️작업 내용
- MainButton JSX / CSS 구현
- disabled, fullWidth 옵션 추가
<img width="304" height="289" alt="스크린샷 2026-04-02 031647" src="https://github.com/user-attachments/assets/1e5139b2-f97a-4eec-a047-0f8d5db85946" />
 
- ProgressBar JSX / CSS 구현
<img width="1581" height="154" alt="스크린샷 2026-04-02 035552" src="https://github.com/user-attachments/assets/f7c3e97d-07c4-4004-a8a8-3e120c28bd8a" />
