### PR TITLE
[feat] 지원하기 모달창 - UI 구현

### DIFF
--- a/FE/src/components/ApplyModal/ApplyModal.css
+++ b/FE/src/components/ApplyModal/ApplyModal.css
@@ -1,0 +1,79 @@
+.apply-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.25);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.apply-modal {
+  width: 350px;
+  background: #ffffff;
+  border-radius: 10px;
+  padding: 20px 24px 18px;
+  box-sizing: border-box;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.apply-modal-title {
+  margin: 5px 0 15px;
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 1.3;
+  color: #111111;
+}
+
+.apply-modal-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.apply-modal-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 17px;
+}
+
+.apply-modal-label {
+  margin-bottom: 8px;
+  font-size: 15px;
+  font-weight: 500;
+  color: #111111;
+}
+
+.apply-modal-input,
+.apply-modal-textarea {
+  width: 100%;
+  border: 1px solid #ABABAB;
+  border-radius: 8px;
+  background: #F1F1F1;
+  font-size: 14px;
+  color: #111111;
+  box-sizing: border-box;
+  outline: none;
+}
+
+.apply-modal-input {
+  height: 27px;
+  padding: 0 12px;
+}
+
+.apply-modal-textarea {
+  min-height: 180px;
+  padding: 5px;
+  resize: none;
+  line-height: 1.5;
+}
+
+.apply-modal-input:focus,
+.apply-modal-textarea:focus {
+  border-color: #f59a57;
+}
+
+.apply-modal-button-wrap {
+  display: flex;
+  justify-content: center;
+  margin-top: 4px;
+}

--- a/FE/src/components/ApplyModal/ApplyModal.jsx
+++ b/FE/src/components/ApplyModal/ApplyModal.jsx
@@ -54,6 +54,8 @@ function ApplyModal({
               className="apply-modal-input"
               value={job}
               onChange={(e) => setJob(e.target.value)}
+              required
+              maxLength={50}
             />
           </div>
 
@@ -69,6 +71,9 @@ function ApplyModal({
               className="apply-modal-textarea"
               value={motivation}
               onChange={(e) => setMotivation(e.target.value)}
+              required
+              minLength={10}
+              maxLength={500}
             />
           </div>
 

--- a/FE/src/components/ApplyModal/ApplyModal.jsx
+++ b/FE/src/components/ApplyModal/ApplyModal.jsx
@@ -1,0 +1,86 @@
+// ApplyModal.jsx
+import { useEffect } from "react";
+import "./ApplyModal.css";
+import MainButton from "../MainButton/MainButton";
+
+function ApplyModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  projectName,
+  job,
+  motivation,
+  setJob,
+  setMotivation,
+}) {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "auto";
+    }
+
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit?.();
+  };
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) {
+      onClose?.();
+    }
+  };
+
+  return (
+    <div className="apply-modal-overlay" onClick={handleOverlayClick}>
+      <div className="apply-modal">
+        <h2 className="apply-modal-title">{projectName}</h2>
+
+        <form className="apply-modal-form" onSubmit={handleSubmit}>
+          <div className="apply-modal-group">
+            <label htmlFor="apply-job" className="apply-modal-label">
+              직무
+            </label>
+            <input
+              id="apply-job"
+              type="text"
+              className="apply-modal-input"
+              value={job}
+              onChange={(e) => setJob(e.target.value)}
+            />
+          </div>
+
+          <div className="apply-modal-group">
+            <label
+              htmlFor="apply-motivation"
+              className="apply-modal-label"
+            >
+              지원 동기 및 자기 PR
+            </label>
+            <textarea
+              id="apply-motivation"
+              className="apply-modal-textarea"
+              value={motivation}
+              onChange={(e) => setMotivation(e.target.value)}
+            />
+          </div>
+
+          <div className="apply-modal-button-wrap">
+            <MainButton type="submit">
+              지원하기
+            </MainButton>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default ApplyModal;


### PR DESCRIPTION
## 📌 개요
지원서 작성을 위한 ApplyModal 컴포넌트를 구현했습니다.

## ⚙️ 작업 내용
- 지원서 입력을 위한 모달 UI 구현
- 입력 폼(직무, 지원 동기) 및 제출 버튼 구성
- overlay 클릭 시 모달 닫기 처리
- 모달 열림 상태 제어 및 배경 스크롤 방지
<img width="1396" height="877" alt="image" src="https://github.com/user-attachments/assets/1fd02f3a-422f-43a3-a353-92be0a127860" />

## 🎸 기타
팀 찾기 페이지에서 지원하기 버튼 클릭 시 노출되는 모달이고, 부모 컴포넌트에서 열림 여부와 입력값을 제어하는 구조로 구현했습니다.