### PR TITLE
[feat] 팀 일정 CRUD 기능 구현 및 임시 인증 로직 적용

### DIFF
--- a/BE/promate/build.gradle
+++ b/BE/promate/build.gradle
@@ -35,7 +35,13 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-web-ui:2.8.13'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+
+    // security
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // validation
+//    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/BE/promate/src/main/java/org/example/promate/domain/project/code/MemberErrorCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/code/MemberErrorCode.java
@@ -1,0 +1,18 @@
+package org.example.promate.domain.project.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.promate.global.ApiPayload.code.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements BaseErrorCode {
+    SCHEDULE_FORBIDDEN_NOT_PROJECT_MEMBER(HttpStatus.FORBIDDEN, "Member_E001", "해당 프로젝트에 속한 사용자만 수행 가능합니다."),
+    ;
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/project/code/ProjectErrorCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/code/ProjectErrorCode.java
@@ -1,0 +1,17 @@
+package org.example.promate.domain.project.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.promate.global.ApiPayload.code.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ProjectErrorCode implements BaseErrorCode {
+    ID_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT_E001", "프로젝트 아이디를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/project/entity/Project.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/entity/Project.java
@@ -59,7 +59,7 @@ public class Project extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
     @Builder.Default
-    private List<Event> events = new ArrayList<>();
+    private List<Schedule> events = new ArrayList<>();
 
     @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
     @Builder.Default

--- a/BE/promate/src/main/java/org/example/promate/domain/project/exception/MemberException.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/exception/MemberException.java
@@ -1,0 +1,10 @@
+package org.example.promate.domain.project.exception;
+
+import org.example.promate.global.ApiPayload.code.BaseErrorCode;
+import org.example.promate.global.ApiPayload.exception.GeneralException;
+
+public class MemberException extends GeneralException {
+    public MemberException(BaseErrorCode code){
+        super(code);
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/project/exception/ProjectException.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/exception/ProjectException.java
@@ -1,0 +1,10 @@
+package org.example.promate.domain.project.exception;
+
+import org.example.promate.global.ApiPayload.code.BaseErrorCode;
+import org.example.promate.global.ApiPayload.exception.GeneralException;
+
+public class ProjectException extends GeneralException {
+    public ProjectException(BaseErrorCode code){
+        super(code);
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/project/respository/MemberRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/respository/MemberRepository.java
@@ -1,0 +1,10 @@
+package org.example.promate.domain.project.respository;
+
+import org.example.promate.domain.project.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByUser_IdAndProject_Id(Long userId, Long projectId);
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/project/respository/ProjectRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/respository/ProjectRepository.java
@@ -1,0 +1,12 @@
+package org.example.promate.domain.project.respository;
+
+import org.example.promate.domain.project.entity.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+    Optional<Project> findById(Long id);
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/code/ScheduleErrorCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/code/ScheduleErrorCode.java
@@ -1,0 +1,19 @@
+package org.example.promate.domain.workspace.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.promate.global.ApiPayload.code.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ScheduleErrorCode implements BaseErrorCode {
+    ID_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE_E001", "해당 일정을 찾을 수 없습니다."),
+    ALREADY_DELETED_SCHEDULE(HttpStatus.BAD_REQUEST, "SCHEDULE_E002", "이미 삭제된 일정입니다."),
+    ;
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/code/ScheduleSuccessCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/code/ScheduleSuccessCode.java
@@ -1,0 +1,21 @@
+package org.example.promate.domain.workspace.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.promate.global.ApiPayload.code.BaseSuccessCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ScheduleSuccessCode implements BaseSuccessCode {
+    CREATED(HttpStatus.CREATED, "SCHEDULE_S001", "팀 일정이 성공적으로 등록되었습니다."),
+    OK(HttpStatus.OK, "SCHEDULE_S002", "팀 일정 조회에 성공했습니다."),
+    DETAILS_OK(HttpStatus.OK, "SCHEDULE_S003", "일정 상세 조회가 완료되었습니다."),
+    MODIFY_SUCCESS(HttpStatus.OK, "SCHEDULE_S004", "일정 수정이 완료되었습니다."),
+    DELETE_SUCCESS(HttpStatus.OK, "SCHEDULE_S005", "일정 삭제가 완료되었습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/controller/api/ScheduleController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/controller/api/ScheduleController.java
@@ -1,0 +1,84 @@
+package org.example.promate.domain.workspace.controller.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.workspace.code.ScheduleSuccessCode;
+import org.example.promate.domain.workspace.controller.docs.ScheduleControllerDocs;
+import org.example.promate.domain.workspace.dto.req.ScheduleReqDto;
+import org.example.promate.domain.workspace.dto.res.ScheduleResDto;
+import org.example.promate.domain.workspace.service.command.ScheduleCommandService;
+import org.example.promate.domain.workspace.service.query.ScheduleQueryService;
+import org.example.promate.global.ApiPayload.ApiResponse;
+import org.example.promate.global.security.CustomPrincipal;
+//import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/projects/{projectId}/schedules")
+public class ScheduleController implements ScheduleControllerDocs {
+    private final ScheduleCommandService scheduleCommandService;
+    private final ScheduleQueryService scheduleQueryService;
+
+    // TODO: 인증 로직 통합 후 제거
+    private final Long userId = 1L;
+
+    // 팀 일정 추가하기(캘린더 UI)
+    @PostMapping()
+    public ApiResponse<ScheduleResDto.AddedScheduleInfoDto> addSchedule(
+//            @AuthenticationPrincipal CustomPrincipal customPrincipal,
+            @PathVariable Long projectId,
+            @Valid @RequestBody ScheduleReqDto.AddScheduleDto dto
+    ){
+//        return ApiResponse.onSuccess(ScheduleSuccessCode.CREATED, scheduleCommandService.addSchedule(customPrincipal.getUserId(), projectId, dto));
+        return ApiResponse.onSuccess(ScheduleSuccessCode.CREATED, scheduleCommandService.addSchedule(userId, projectId, dto));
+
+    }
+
+    // 팀 일정 조회하기
+    @GetMapping()
+    public ApiResponse<ScheduleResDto.MonthlyScheduleListInfoDto> getMonthlySchedules(
+//            @AuthenticationPrincipal CustomPrincipal customPrincipal,
+            @PathVariable Long projectId,
+            @RequestParam(name="year") Integer year,
+            @RequestParam(name="month") Integer month
+
+    ){
+//        return ApiResponse.onSuccess(ScheduleSuccessCode.OK, scheduleQueryService.getMonthlySchedules(customPrincipal.getUserId(), projectId, year, month));
+        return ApiResponse.onSuccess(ScheduleSuccessCode.OK, scheduleQueryService.getMonthlySchedules(userId, projectId, year, month));
+    }
+
+    // 팀 일정 상세 조회하기
+    @GetMapping("{scheduleId}")
+    public ApiResponse<ScheduleResDto.ProjectScheduleDetailInfoDto> getScheduleDetails(
+//            @AuthenticationPrincipal CustomPrincipal customPrincipal,
+            @PathVariable Long projectId,
+            @PathVariable Long scheduleId
+    ){
+//        return ApiResponse.onSuccess(ScheduleSuccessCode.DETAILS_OK, scheduleQueryService.getScheduleDetails(customPrincipal.getUserId(), projectId, scheduleId));
+        return ApiResponse.onSuccess(ScheduleSuccessCode.DETAILS_OK, scheduleQueryService.getScheduleDetails(userId, projectId, scheduleId));
+    }
+
+    // 팀 일정 수정하기
+    @PutMapping("/{scheduleId}")
+    public ApiResponse<ScheduleResDto.ModifiedScheduleInfoDto> modifySchedule(
+//            @AuthenticationPrincipal CustomPrincipal customPrincipal,
+            @PathVariable Long projectId,
+            @PathVariable Long scheduleId,
+            @Valid @RequestBody ScheduleReqDto.ModifyScheduleDto dto
+    ){
+//        return ApiResponse.onSuccess(ScheduleSuccessCode.MODIFY_SUCCESS, scheduleCommandService.modifySchedule(customPrincipal.getUserId(), projectId, scheduleId, dto));
+        return ApiResponse.onSuccess(ScheduleSuccessCode.MODIFY_SUCCESS, scheduleCommandService.modifySchedule(userId, projectId, scheduleId, dto));
+    }
+
+    // 팀 일정 삭제하기
+    @DeleteMapping("/{scheduleId}")
+    public ApiResponse<ScheduleResDto.DeletedScheduleInfoDto> modifySchedule(
+//            @AuthenticationPrincipal CustomPrincipal customPrincipal,
+            @PathVariable Long projectId,
+            @PathVariable Long scheduleId
+    ){
+//        return ApiResponse.onSuccess(ScheduleSuccessCode.DELETE_SUCCESS, scheduleCommandService.deleteSchedule(customPrincipal.getUserId(), projectId, scheduleId));
+        return ApiResponse.onSuccess(ScheduleSuccessCode.DELETE_SUCCESS, scheduleCommandService.deleteSchedule(userId, projectId, scheduleId));
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/controller/api/ScheduleController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/controller/api/ScheduleController.java
@@ -73,7 +73,7 @@ public class ScheduleController implements ScheduleControllerDocs {
 
     // 팀 일정 삭제하기
     @DeleteMapping("/{scheduleId}")
-    public ApiResponse<ScheduleResDto.DeletedScheduleInfoDto> modifySchedule(
+    public ApiResponse<ScheduleResDto.DeletedScheduleInfoDto> deleteSchedule(
 //            @AuthenticationPrincipal CustomPrincipal customPrincipal,
             @PathVariable Long projectId,
             @PathVariable Long scheduleId

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/controller/docs/ScheduleControllerDocs.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/controller/docs/ScheduleControllerDocs.java
@@ -118,7 +118,7 @@ public interface ScheduleControllerDocs {
             )
     })
     @DeleteMapping("/projects/{projectId}/schedules/{scheduleId}")
-    ApiResponse<ScheduleResDto.DeletedScheduleInfoDto> modifySchedule(
+    ApiResponse<ScheduleResDto.DeletedScheduleInfoDto> deleteSchedule(
 //            @AuthenticationPrincipal CustomPrincipal customPrincipal,
             @PathVariable Long projectId,
             @PathVariable Long scheduleId

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/controller/docs/ScheduleControllerDocs.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/controller/docs/ScheduleControllerDocs.java
@@ -1,0 +1,126 @@
+package org.example.promate.domain.workspace.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.example.promate.domain.workspace.dto.req.ScheduleReqDto;
+import org.example.promate.domain.workspace.dto.res.ScheduleResDto;
+import org.example.promate.global.ApiPayload.ApiResponse;
+import org.example.promate.global.security.CustomPrincipal;
+//import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+
+@Tag(name = "WORKSPACE_SCHEDULE", description = "WORKSPACE 도메인 내 팀 일정 관리 API")
+public interface ScheduleControllerDocs {
+
+    // 팀 일정 추가하기(캘린더 UI)
+    @Operation(
+            summary = "SCHEDULE_01 팀 일정 추가하기",
+            operationId = "WORKSPACE_SCHEDULE_01",
+            description = "캘린더 UI에 활용될 팀 일정을 추가합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "일정 추가 성공 (SCHEDULE_S001)",
+                    content = @Content(schema = @Schema(implementation = ScheduleResDto.AddedScheduleInfoDto.class))
+            )
+    })
+    @PostMapping("/projects/{projectId}/schedules")
+    ApiResponse<ScheduleResDto.AddedScheduleInfoDto> addSchedule(
+//            @AuthenticationPrincipal CustomPrincipal customPrincipal,
+            @PathVariable Long projectId,
+            @Valid @RequestBody ScheduleReqDto.AddScheduleDto dto
+    );
+
+    // 팀 일정 조회하기
+    @Operation(
+            summary = "SCHEDULE_02 팀 일정 조회하기",
+            operationId = "WORKSPACE_SCHEDULE_02",
+            description = "캘린더 UI로 보여줄 팀 일정 목록을 조회합니다."
+
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "일정 조회 성공 (SCHEDULE_S002)",
+                    content = @Content(schema = @Schema(implementation = ScheduleResDto.MonthlyScheduleListInfoDto.class))
+            )
+    })
+    @GetMapping("/projects/{projectId}/schedules")
+    ApiResponse<ScheduleResDto.MonthlyScheduleListInfoDto> getMonthlySchedules(
+//            @AuthenticationPrincipal CustomPrincipal customPrincipal,
+            @PathVariable Long projectId,
+            @RequestParam(name = "year") Integer year,
+            @RequestParam(name = "month") Integer month
+
+    );
+
+    // 팀 일정 상세 조회하기
+    @Operation(
+            summary = "SCHEDULE_03 팀 일정 상세 조회하기",
+            operationId = "WORKSPACE_SCHEDULE_03",
+            description = "특정 팀 일정의 상세 정보를 조회합니다."
+
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "일정 조회 성공 (SCHEDULE_S003)",
+                    content = @Content(schema = @Schema(implementation = ScheduleResDto.ProjectScheduleDetailInfoDto.class))
+            )
+    })
+    @GetMapping("/projects/{projectId}/schedules/{scheduleId}")
+    ApiResponse<ScheduleResDto.ProjectScheduleDetailInfoDto> getScheduleDetails(
+//            @AuthenticationPrincipal CustomPrincipal customPrincipal,
+            @PathVariable Long projectId,
+            @PathVariable Long scheduleId
+    );
+
+    // 팀 일정 수정하기
+    @Operation(
+            summary = "SCHEDULE_04 팀 일정 수정하기",
+            operationId = "WORKSPACE_SCHEDULE_04",
+            description = "팀 일정을 수정합니다."
+
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "일정 수정 성공 (SCHEDULE_S004)",
+                    content = @Content(schema = @Schema(implementation = ScheduleResDto.ModifiedScheduleInfoDto.class))
+            )
+    })
+    @PutMapping("/projects/{projectId}/schedules/{scheduleId}")
+    ApiResponse<ScheduleResDto.ModifiedScheduleInfoDto> modifySchedule(
+//            @AuthenticationPrincipal CustomPrincipal customPrincipal,
+            @PathVariable Long projectId,
+            @PathVariable Long scheduleId,
+            @Valid @RequestBody ScheduleReqDto.ModifyScheduleDto dto
+    );
+
+    // 팀 일정 삭제하기
+    @Operation(
+            summary = "SCHEDULE_05 팀 일정 삭제하기",
+            operationId = "WORKSPACE_SCHEDULE_05",
+            description = "팀 일정을 삭제합니다."
+
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "일정 삭제 성공 (SCHEDULE_S005)",
+                    content = @Content(schema = @Schema(implementation = ScheduleResDto.DeletedScheduleInfoDto.class))
+            )
+    })
+    @DeleteMapping("/projects/{projectId}/schedules/{scheduleId}")
+    ApiResponse<ScheduleResDto.DeletedScheduleInfoDto> modifySchedule(
+//            @AuthenticationPrincipal CustomPrincipal customPrincipal,
+            @PathVariable Long projectId,
+            @PathVariable Long scheduleId
+    );
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/converter/ScheduleConverter.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/converter/ScheduleConverter.java
@@ -1,0 +1,80 @@
+package org.example.promate.domain.workspace.converter;
+
+import org.example.promate.domain.project.entity.Project;
+import org.example.promate.domain.workspace.dto.req.ScheduleReqDto;
+import org.example.promate.domain.workspace.dto.res.ScheduleResDto;
+import org.example.promate.domain.workspace.entity.Schedule;
+
+import java.util.List;
+
+public class ScheduleConverter {
+    // dto -> entity
+    public static Schedule toEntity(ScheduleReqDto.AddScheduleDto dto, Project project){
+        return Schedule.builder()
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .startAt(dto.getStartDate())
+                .endAt(dto.getEndDate())
+                .project(project)
+                .build();
+    }
+
+    //entity -> dto
+    public static ScheduleResDto.AddedScheduleInfoDto toAddedInfoDto(Schedule entity){
+        return ScheduleResDto.AddedScheduleInfoDto.builder()
+                .scheduleId(entity.getId())
+                .projectId(entity.getProject().getId())
+                .title(entity.getTitle())
+                .startDate(entity.getStartAt())
+                .endDate(entity.getEndAt())
+                .build();
+    }
+
+    // entity -> listDto
+    public static ScheduleResDto.MonthlyScheduleListInfoDto toMonthlyScheduleListInfoDto(List<Schedule> monthlySchedule){
+        return ScheduleResDto.MonthlyScheduleListInfoDto.builder()
+                .monthlyScheduleList(monthlySchedule.stream()
+                        .map(schedule -> toMonthlyScheduleInfoDto(schedule))
+                        .toList())
+                .build();
+    }
+
+    // entity -> dto
+    public static ScheduleResDto.MonthlyScheduleInfoDto toMonthlyScheduleInfoDto(Schedule entity){
+        return ScheduleResDto.MonthlyScheduleInfoDto.builder()
+                .scheduleId(entity.getId())
+                .title(entity.getTitle())
+                .startDate(entity.getStartAt())
+                .endDate(entity.getEndAt())
+                .build();
+    }
+
+    // entity -> dto
+    public static ScheduleResDto.ProjectScheduleDetailInfoDto toScheduleDetailInfoDto(Schedule entity){
+        return ScheduleResDto.ProjectScheduleDetailInfoDto.builder()
+                .scheduleId(entity.getId())
+                .title(entity.getTitle())
+                .content(entity.getContent())
+                .startDate(entity.getStartAt())
+                .endDate(entity.getEndAt())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    //entity -> dto
+    public static ScheduleResDto.ModifiedScheduleInfoDto toModifiedScheduleInfoDto(Schedule entity){
+        return ScheduleResDto.ModifiedScheduleInfoDto.builder()
+                .scheduleId(entity.getId())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    // entity -> dto
+    public static ScheduleResDto.DeletedScheduleInfoDto toDeletedScheduleInfoDto(Schedule entity){
+        return ScheduleResDto.DeletedScheduleInfoDto.builder()
+                .scheduleId(entity.getId())
+                .deletedAt(entity.getDeletedAt())
+                .build();
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/dto/req/ScheduleReqDto.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/dto/req/ScheduleReqDto.java
@@ -1,0 +1,41 @@
+package org.example.promate.domain.workspace.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class ScheduleReqDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class AddScheduleDto {
+        @NotBlank(message = "제목을 입력해 주세요.")
+        private String title;
+
+        private String content;
+
+        @NotNull(message = "시작 날짜는 필수입니다.")
+        private LocalDate startDate;
+
+        @NotNull(message = "종료 날짜는 필수입니다.")
+        private LocalDate endDate;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ModifyScheduleDto {
+        @NotBlank(message = "제목을 입력해 주세요.")
+        private String title;
+
+        private String content;
+
+        @NotNull(message = "시작 날짜는 필수입니다.")
+        private LocalDate startDate;
+
+        @NotNull(message = "종료 날짜는 필수입니다.")
+        private LocalDate endDate;
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/dto/res/ScheduleResDto.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/dto/res/ScheduleResDto.java
@@ -1,0 +1,74 @@
+package org.example.promate.domain.workspace.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ScheduleResDto {
+
+    @Builder
+    @Getter
+    @JsonPropertyOrder({"scheduleId", "projectId", "title", "startDate", "endDate"})
+    public static class AddedScheduleInfoDto{
+        private Long scheduleId;
+        private Long projectId;
+        private String title;
+        private LocalDate startDate;
+        private LocalDate endDate;
+    }
+
+    //월간 개별 스케줄
+    @Builder
+    @Getter
+    @JsonPropertyOrder({"scheduleId", "title", "startDate", "endDate"})
+    public static class MonthlyScheduleInfoDto{
+        private Long scheduleId;
+        private String title;
+        private LocalDate startDate;
+        private LocalDate endDate;
+    }
+
+    //월간 스케줄 리스트 목록
+    @Builder
+    @Getter
+    public static class MonthlyScheduleListInfoDto{
+        List<MonthlyScheduleInfoDto> monthlyScheduleList;
+    }
+
+    //팀 일정 상세 조회
+    @Builder
+    @Getter
+    @JsonPropertyOrder({"scheduleId", "title", "content", "startDate", "endDate", "createdAt", "updatedAt"})
+    public static class ProjectScheduleDetailInfoDto{
+        private Long scheduleId;
+        private String title;
+        private String content;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+
+    // 팀 일정 수정하기
+    @Builder
+    @Getter
+    @JsonPropertyOrder({"scheduleId", "updatedAt"})
+    public static class ModifiedScheduleInfoDto{
+        private Long scheduleId;
+        private LocalDateTime updatedAt;
+    }
+
+    // 팀 일정 삭제하기
+    @Builder
+    @Getter
+    @JsonPropertyOrder({"scheduleId", "deletedAt"})
+    public static class DeletedScheduleInfoDto{
+        private Long scheduleId;
+        private LocalDateTime deletedAt;
+    }
+
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/Schedule.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/Schedule.java
@@ -13,8 +13,8 @@ import java.time.LocalDate;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name="event")
-public class Event extends BaseEntity {    //캘린더 등록
+@Table(name="schedule")
+public class Schedule extends BaseEntity {    //캘린더 등록
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -35,4 +35,12 @@ public class Event extends BaseEntity {    //캘린더 등록
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="project_id")
     private Project project;
+
+    // 팀 일정 수정 메서드
+    public void modify(String title, String content, LocalDate startAt, LocalDate endAt){
+        this.title = title;
+        this.content = content;
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/exception/ScheduleException.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/exception/ScheduleException.java
@@ -1,0 +1,10 @@
+package org.example.promate.domain.workspace.exception;
+
+import org.example.promate.global.ApiPayload.code.BaseErrorCode;
+import org.example.promate.global.ApiPayload.exception.GeneralException;
+
+public class ScheduleException extends GeneralException {
+    public ScheduleException(BaseErrorCode code){
+        super(code);
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/ScheduleRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/ScheduleRepository.java
@@ -1,0 +1,32 @@
+package org.example.promate.domain.workspace.repository;
+
+import org.example.promate.domain.workspace.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    @Query("SELECT s FROM Schedule s " +
+            "WHERE s.project.id = :projectId " + // 프로젝트 필터링 추가
+
+            // 03/25~04/02 의 일정인 경우 03/01~03/31 기간 조회 시 검색 안 됨
+            // 따라서 시작일이 검색하고자 하는 월의 마지막 날 이전이고, 마감일이 검색하고자 하는 월의 시작일 이후면 검색
+            "AND s.startAt <= :searchEnd " +     // 기간 조건 1
+            "AND s.endAt >= :searchStart")
+        // 기간 조건 2
+    List<Schedule> findSchedulesByProjectAndMonth(
+            @Param("projectId") Long projectId,
+            @Param("searchStart") LocalDate searchStart,
+            @Param("searchEnd") LocalDate searchEnd
+    );
+
+    Optional<Schedule> findByIdAndIsDeletedFalse(Long id);
+
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/service/command/ScheduleCommandService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/service/command/ScheduleCommandService.java
@@ -1,0 +1,10 @@
+package org.example.promate.domain.workspace.service.command;
+
+import org.example.promate.domain.workspace.dto.req.ScheduleReqDto;
+import org.example.promate.domain.workspace.dto.res.ScheduleResDto;
+
+public interface ScheduleCommandService {
+    ScheduleResDto.AddedScheduleInfoDto addSchedule(Long userId, Long projectId, ScheduleReqDto.AddScheduleDto dto);
+    ScheduleResDto.ModifiedScheduleInfoDto modifySchedule(Long userId, Long projectId, Long scheduleId, ScheduleReqDto.ModifyScheduleDto dto);
+    ScheduleResDto.DeletedScheduleInfoDto deleteSchedule(Long userId, Long projectId, Long scheduleId);
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/service/command/ScheduleCommandServiceImpl.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/service/command/ScheduleCommandServiceImpl.java
@@ -1,0 +1,74 @@
+package org.example.promate.domain.workspace.service.command;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.project.code.MemberErrorCode;
+import org.example.promate.domain.project.code.ProjectErrorCode;
+import org.example.promate.domain.project.entity.Project;
+import org.example.promate.domain.project.exception.MemberException;
+import org.example.promate.domain.project.exception.ProjectException;
+import org.example.promate.domain.project.respository.MemberRepository;
+import org.example.promate.domain.project.respository.ProjectRepository;
+import org.example.promate.domain.workspace.code.ScheduleErrorCode;
+import org.example.promate.domain.workspace.converter.ScheduleConverter;
+import org.example.promate.domain.workspace.dto.req.ScheduleReqDto;
+import org.example.promate.domain.workspace.dto.res.ScheduleResDto;
+import org.example.promate.domain.workspace.entity.Schedule;
+import org.example.promate.domain.workspace.exception.ScheduleException;
+import org.example.promate.domain.workspace.repository.ScheduleRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ScheduleCommandServiceImpl implements ScheduleCommandService{
+    private final ProjectRepository projectRepository;
+    private final MemberRepository memberRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    // 팀 일정 추가하기
+    @Override
+    public ScheduleResDto.AddedScheduleInfoDto addSchedule(Long userId, Long projectId, ScheduleReqDto.AddScheduleDto dto) {
+        //사용자가 해당 프로젝트의 팀원인지 확인
+        if(!memberRepository.existsByUser_IdAndProject_Id(userId, projectId)){
+            throw new MemberException(MemberErrorCode.SCHEDULE_FORBIDDEN_NOT_PROJECT_MEMBER);
+        }
+
+        Project project = projectRepository.findById(projectId).orElseThrow(() -> new ProjectException(ProjectErrorCode.ID_NOT_FOUND));
+
+        Schedule entity = ScheduleConverter.toEntity(dto, project);
+        Schedule saved = scheduleRepository.save(entity);
+
+        return ScheduleConverter.toAddedInfoDto(saved);
+    }
+
+    // 팀 일정 수정하기
+    @Override
+    public ScheduleResDto.ModifiedScheduleInfoDto modifySchedule(Long userId, Long projectId, Long scheduleId, ScheduleReqDto.ModifyScheduleDto dto) {
+        //사용자가 해당 프로젝트의 팀원인지 확인
+        if(!memberRepository.existsByUser_IdAndProject_Id(userId, projectId)){
+            throw new MemberException(MemberErrorCode.SCHEDULE_FORBIDDEN_NOT_PROJECT_MEMBER);
+        }
+
+        Schedule schedule = scheduleRepository.findByIdAndIsDeletedFalse(scheduleId).orElseThrow(() -> new ScheduleException(ScheduleErrorCode.ID_NOT_FOUND));
+
+        schedule.modify(dto.getTitle(), dto.getContent(), dto.getStartDate(), dto.getEndDate());
+
+        return ScheduleConverter.toModifiedScheduleInfoDto(schedule);
+    }
+
+    // 팀 일정 삭제하기
+    @Override
+    public ScheduleResDto.DeletedScheduleInfoDto deleteSchedule(Long userId, Long projectId, Long scheduleId) {
+        //사용자가 해당 프로젝트의 팀원인지 확인
+        if(!memberRepository.existsByUser_IdAndProject_Id(userId, projectId)){
+            throw new MemberException(MemberErrorCode.SCHEDULE_FORBIDDEN_NOT_PROJECT_MEMBER);
+        }
+
+        Schedule schedule = scheduleRepository.findByIdAndIsDeletedFalse(scheduleId).orElseThrow(() -> new ScheduleException(ScheduleErrorCode.ID_NOT_FOUND));
+
+        schedule.delete();
+
+        return ScheduleConverter.toDeletedScheduleInfoDto(schedule);
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/service/query/ScheduleQueryService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/service/query/ScheduleQueryService.java
@@ -1,0 +1,9 @@
+package org.example.promate.domain.workspace.service.query;
+
+import org.example.promate.domain.workspace.dto.res.ScheduleResDto;
+
+public interface ScheduleQueryService {
+    ScheduleResDto.MonthlyScheduleListInfoDto getMonthlySchedules(Long userId, Long projectId, Integer year, Integer month);
+    ScheduleResDto.ProjectScheduleDetailInfoDto getScheduleDetails(Long userId, Long projectId, Long scheduleId);
+
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/service/query/ScheduleQueryServiceImpl.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/service/query/ScheduleQueryServiceImpl.java
@@ -1,0 +1,54 @@
+package org.example.promate.domain.workspace.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.project.code.MemberErrorCode;
+import org.example.promate.domain.project.exception.MemberException;
+import org.example.promate.domain.project.respository.MemberRepository;
+import org.example.promate.domain.workspace.code.ScheduleErrorCode;
+import org.example.promate.domain.workspace.converter.ScheduleConverter;
+import org.example.promate.domain.workspace.dto.res.ScheduleResDto;
+import org.example.promate.domain.workspace.entity.Schedule;
+import org.example.promate.domain.workspace.exception.ScheduleException;
+import org.example.promate.domain.workspace.repository.ScheduleRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleQueryServiceImpl implements ScheduleQueryService{
+    private final ScheduleRepository scheduleRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public ScheduleResDto.MonthlyScheduleListInfoDto getMonthlySchedules(Long userId, Long projectId, Integer year, Integer month) {
+        //사용자가 해당 프로젝트의 팀원인지 확인
+        if(!memberRepository.existsByUser_IdAndProject_Id(userId, projectId)){
+            throw new MemberException(MemberErrorCode.SCHEDULE_FORBIDDEN_NOT_PROJECT_MEMBER);
+        }
+
+        // 검색 달 계산
+        YearMonth target = YearMonth.of(year, month);
+
+        LocalDate searchStart = target.atDay(1);
+        LocalDate searchEnd = target.atEndOfMonth();
+
+        List<Schedule> monthlySchedule = scheduleRepository.findSchedulesByProjectAndMonth(projectId, searchStart, searchEnd);
+
+        return ScheduleConverter.toMonthlyScheduleListInfoDto(monthlySchedule);
+    }
+
+    @Override
+    public ScheduleResDto.ProjectScheduleDetailInfoDto getScheduleDetails(Long userId, Long projectId, Long scheduleId) {
+        //사용자가 해당 프로젝트의 팀원인지 확인
+        if(!memberRepository.existsByUser_IdAndProject_Id(userId, projectId)){
+            throw new MemberException(MemberErrorCode.SCHEDULE_FORBIDDEN_NOT_PROJECT_MEMBER);
+        }
+
+        Schedule schedule = scheduleRepository.findById(scheduleId).orElseThrow(() -> new ScheduleException(ScheduleErrorCode.ID_NOT_FOUND));
+
+        return ScheduleConverter.toScheduleDetailInfoDto(schedule);
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/global/entity/BaseEntity.java
+++ b/BE/promate/src/main/java/org/example/promate/global/entity/BaseEntity.java
@@ -28,4 +28,10 @@ public class BaseEntity extends BaseTimeEntity{
 
     @Column(name="deleted_at")
     private LocalDateTime deletedAt;
+
+    // 삭제 메서드
+    public void delete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/BE/promate/src/main/java/org/example/promate/global/security/CustomPrincipal.java
+++ b/BE/promate/src/main/java/org/example/promate/global/security/CustomPrincipal.java
@@ -1,0 +1,10 @@
+package org.example.promate.global.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomPrincipal {
+    Long userId;
+}


### PR DESCRIPTION
## 📌 개요
워크스페이스 내 팀 일정 관리를 위한 CRUD 기능을 구현했습니다.. 컨트롤러와 서비스 레이어의 세부 비즈니스 로직을 연결하였으며, FE 협업을 위한 Swagger 문서 설정을 완료했습니다.

## ⚙️ 작업 내용
- 팀 일정 관리 CRUD API 완성: 팀 일정 생성, 월간 조회, 상세 조회, 수정, 삭제 기능 구현
- CQRS 기반 비즈니스 로직 연동
    - `ScheduleCommandService`: 일정의 상태를 변경하는 로직 처리
    - `ScheduleQueryService`: 조회 성능 및 효율을 위한 조회 전용 로직 처리
- Swagger 문서화: `ScheduleControllerDocs `인터페이스를 통한 API 명세 및 Swagger 상세 설정 완료
 
## 🎸 기타사항
- 추후 security 기능 통합 시 주석 처리된 코드로 리팩토링 예정
