### PR TITLE
[feat] 공통 - 헤더 및 사이드바 라우팅 추가

### DIFF
--- a/FE/src/components/Header/Header.jsx
+++ b/FE/src/components/Header/Header.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { getUserInfo } from '../../api/UserApi';
 import logoImg from '../../assets/promate_logo.svg';
 import './Header.css';
@@ -30,7 +31,9 @@ function Header({ onMenuClick }) {
           <span></span><span></span><span></span>
         </button>
         <div className="header-logo">
-          <img src={logoImg} alt="ProMate 로고" className="logo-image" />
+          <Link to="/" className="logo-link">
+            <img src={logoImg} alt="ProMate 로고" className="logo-image" />
+          </Link>
           <span className="logo-sub">최고의 팀과 협업하세요.</span>
         </div>
       </div>

--- a/FE/src/components/SideBar/Sidebar.jsx
+++ b/FE/src/components/SideBar/Sidebar.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'; 
+import { useNavigate } from 'react-router-dom';
 import './Sidebar.css'; 
 import SidebarItem from "./SidebarItem";
 import FavoriteItem from "./FavoriteItem";
@@ -18,6 +19,7 @@ import profileOrangeIcon from "../../assets/icons/profileOrangeIcon.svg";
 function Sidebar({ isOpen, onClose }) {
   const [favoriteList, setFavoriteList] = useState([]); 
   const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
   
   useEffect(() => {
     const fetchProjects = async () => {
@@ -92,7 +94,7 @@ function Sidebar({ isOpen, onClose }) {
         </div>
         <hr className="divider" />
 
-        <button className="new-project-btn">
+        <button className="new-project-btn" onClick={() => navigate('/teammaking')}>
           + 새 프로젝트 생성
         </button>
 


### PR DESCRIPTION
## 📌 개요
헤더에 로고 클릭 시 대시보드로 이동하고, 사이드바에 '새 프로젝트 생성' 버튼 클릭 시 teammaking 페이지로 이동할 수 있도록 설정했습니다.

## ⚙️ 작업 내용
- 헤더 로고 클릭 시 대시보드 페이지로 이동하도록 설정
- 사이드바 버튼 클릭 시 팀메이킹 페이지로 이동하도록 설정
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
