### PR TITLE
[refactor] 대시보드 페이지 - 카드 및 캘린더 UI 개선

### DIFF
--- a/FE/src/pages/DashboardPage/DashboardPage.css
+++ b/FE/src/pages/DashboardPage/DashboardPage.css
@@ -22,8 +22,9 @@
   flex-direction: column;
   gap: 30px;
   width: 100%;
-  max-width: 1400px;
-  margin: 0 auto;
+  max-width: 1450px;
+  margin-left: 0;
+  margin-right: auto;
   filter: drop-shadow(0px 0px 10px rgba(0, 0, 0, 0.05));
 }
 
@@ -52,7 +53,7 @@
   flex-direction: column;
   gap: 20px;
   flex: 1;
-  min-width: 350px;
+  min-width: 280px;
 }
 
 .section-header {

--- a/FE/src/pages/DashboardPage/DashboardPage.css
+++ b/FE/src/pages/DashboardPage/DashboardPage.css
@@ -4,6 +4,7 @@
   width: 100%;
   height: calc(100vh - 56px);
   background: linear-gradient(180deg, #F0F0F0 0%, #FFFFFF 100%);
+  overflow: hidden;
   overflow-y: auto;
   padding: 19px 50px 0 30px;
   box-sizing: border-box;
@@ -15,6 +16,7 @@
   font-weight: 500;
   margin-bottom: 20px;
   color: #000000;
+  flex-shrink: 0;
 }
 
 .dashboard-content {
@@ -26,6 +28,9 @@
   margin-left: 0;
   margin-right: auto;
   filter: drop-shadow(0px 0px 10px rgba(0, 0, 0, 0.05));
+  flex: 1;
+  overflow-y: auto;
+  padding-bottom: 30px;
 }
 
 .dashboard-summary-row {

--- a/FE/src/pages/DashboardPage/DashboardPage.css
+++ b/FE/src/pages/DashboardPage/DashboardPage.css
@@ -5,7 +5,7 @@
   height: calc(100vh - 56px);
   background: linear-gradient(180deg, #F0F0F0 0%, #FFFFFF 100%);
   overflow-y: auto;
-  padding: 19px 50px 0 30px;
+  padding: 19px 50px 20px 30px;
   box-sizing: border-box;
 }
 
@@ -28,7 +28,8 @@
   margin-right: auto;
   filter: drop-shadow(0px 0px 10px rgba(0, 0, 0, 0.05));
 
-  flex: initial;
+  flex: 1;
+  min-height: 0;
   overflow: visible;
   padding-bottom: 0;
 }
@@ -39,6 +40,7 @@
   flex-wrap: wrap;
   gap: 20px;
   width: 100%;
+  flex-shrink: 0;
 }
 
 .dashboard-detail-row {
@@ -48,6 +50,8 @@
   gap: 20px;
   width: 100%;
   margin-bottom: 0;
+  flex: 1;
+  min-height: 0;
 }
 
 .status-section {
@@ -60,6 +64,7 @@
   gap: 20px;
   flex: 1;
   min-width: 280px;
+  min-height: 0;
 }
 
 .section-header {
@@ -82,6 +87,9 @@
   gap: 5px;
   border-top: 1px solid #D9D9D9;
   padding-top: 10px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 @media (max-width: 768px) {
@@ -91,6 +99,8 @@
 
   .dashboard-content {
     gap: 24px;
+    flex: initial;
+    min-height: auto;
   }
 
   .dashboard-summary-row,
@@ -99,9 +109,16 @@
     gap: 16px;
   }
 
+  .dashboard-detail-row {
+    flex: initial;
+    min-height: auto;
+  }
+
   .status-section {
     padding: 20px 16px;
     min-width: 0;
     width: 100%;
+    flex: initial;
+    min-height: auto;
   }
 }

--- a/FE/src/pages/DashboardPage/DashboardPage.css
+++ b/FE/src/pages/DashboardPage/DashboardPage.css
@@ -27,8 +27,10 @@
   margin-left: 0;
   margin-right: auto;
   filter: drop-shadow(0px 0px 10px rgba(0, 0, 0, 0.05));
-  flex: 1;
-  padding-bottom: 30px;
+
+  flex: initial;
+  overflow: visible;
+  padding-bottom: 0;
 }
 
 .dashboard-summary-row {
@@ -45,6 +47,7 @@
   flex-wrap: wrap;
   gap: 20px;
   width: 100%;
+  margin-bottom: 0;
 }
 
 .status-section {
@@ -85,14 +88,17 @@
   .dashboard-container {
     padding: 20px 16px;
   }
+
   .dashboard-content {
     gap: 24px;
   }
+
   .dashboard-summary-row,
   .dashboard-detail-row {
     flex-direction: column;
     gap: 16px;
   }
+
   .status-section {
     padding: 20px 16px;
     min-width: 0;

--- a/FE/src/pages/DashboardPage/DashboardPage.css
+++ b/FE/src/pages/DashboardPage/DashboardPage.css
@@ -78,9 +78,9 @@
 .status-list {
   display: flex;
   flex-direction: column;
-  gap: 25px;
+  gap: 5px;
   border-top: 1px solid #D9D9D9;
-  padding-top: 20px;
+  padding-top: 10px;
 }
 
 @media (max-width: 768px) {

--- a/FE/src/pages/DashboardPage/DashboardPage.css
+++ b/FE/src/pages/DashboardPage/DashboardPage.css
@@ -2,12 +2,10 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
+  height: calc(100vh - 56px);
   background: linear-gradient(180deg, #F0F0F0 0%, #FFFFFF 100%);
   overflow-y: auto;
-  padding-left: 30px;
-  padding-top: 20px;
-  padding-right: 50px;
+  padding: 19px 50px 0 30px;
   box-sizing: border-box;
 }
 

--- a/FE/src/pages/DashboardPage/DashboardPage.css
+++ b/FE/src/pages/DashboardPage/DashboardPage.css
@@ -4,7 +4,6 @@
   width: 100%;
   height: calc(100vh - 56px);
   background: linear-gradient(180deg, #F0F0F0 0%, #FFFFFF 100%);
-  overflow: hidden;
   overflow-y: auto;
   padding: 19px 50px 0 30px;
   box-sizing: border-box;
@@ -29,7 +28,6 @@
   margin-right: auto;
   filter: drop-shadow(0px 0px 10px rgba(0, 0, 0, 0.05));
   flex: 1;
-  overflow-y: auto;
   padding-bottom: 30px;
 }
 

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -10,19 +10,18 @@ import moreIcon from '../../assets/moreIcon.svg';
 const dummyDashboardData = {
   projects: [
     { id: 1, title: '캡스톤 디자인', date: '2026.05.08', ratio: '12/18' },
-    { id: 2, title: '팀플 과제', date: '2026.06.01', ratio: '5/10' },
-    { id: 3, title: 'WAP 프로젝트', date: '2026.06.05', ratio: '3/18' },
-    { id: 4, title: '토이 프로젝트', date: '2026.07.12', ratio: '2/8' },
+    { id: 2, title: 'WAP 프로젝트', date: '2026.06.05', ratio: '3/18' },
   ],
   urgentTasks: [
     { id: 1, title: '캡스톤 디자인 - 자료 조사하기', date: '2026.05.05' },
     { id: 2, title: 'WAP 프로젝트 - 중간 발표', date: '2026.05.06' },
-    { id: 3, title: '팀플 과제 - PPT 제작', date: '2026.05.17' },
-    { id: 4, title: '팀플 과제 - PPT 제작', date: '2026.05.19' },
+    
   ],
   completedTasks: [
-    { id: 1, title: 'WAP 프로젝트', date: '2025.11.28' },
-    { id: 2, title: '팀플 과제', date: '2026.04.01' },
+    { id: 1, title: 'WAP 프로젝트 - 대시보드 개발', date: '2025.11.28' },
+    { id: 2, title: '프로그래밍 팀플 - 오류 수정', date: '2026.04.01' },
+    { id: 3, title: '프로그래밍 팀플 - PPT 제작', date: '2026.04.17' },
+    { id: 4, title: '캡스톤 디자인 - 프로젝트 계획서 작성', date: '2026.05.01' },
   ],
 };
 

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -4,7 +4,6 @@ import Calendar from './components/Calendar';
 import projectMenuIcon from '../../assets/projectMenuIcon.svg';
 import SummaryCard from './components/SummaryCard';
 import StatusItem from './components/StatusItem';
-import moreIcon from '../../assets/moreIcon.svg';
 
 // 임시 데이터
 const dummyDashboardData = {
@@ -33,7 +32,6 @@ function DashboardPage() {
   });
 
   const [isLoading, setIsLoading] = useState(true);
-  const [visibleStatusCount, setVisibleStatusCount] = useState(3);
 
   useEffect(() => {
     // 백엔드 API 연결 시 이 부분 수정
@@ -73,10 +71,6 @@ function DashboardPage() {
     [dashboardData]
   );
 
-  const handleShowMoreStatus = () => {
-    setVisibleStatusCount((prevCount) => prevCount + 3);
-  };
-
   if (isLoading) {
     return (
       <div className="dashboard-container">
@@ -113,7 +107,8 @@ function DashboardPage() {
             </div>
 
             <div className="status-list">
-              {dashboardData.activeProjects.slice(0, visibleStatusCount).map((project) => (
+              {dashboardData.projectStatuses.map((project) => (
+              {dashboardData.activeProjects.map((project) => (
                 <StatusItem
                   key={project.id}
                   id={project.id}
@@ -123,25 +118,6 @@ function DashboardPage() {
                 />
               ))}
             </div>
-
-            {visibleStatusCount < dashboardData.activeProjects.length ? (
-              <button 
-                className="more-btn" 
-                onClick={handleShowMoreStatus} 
-                style={{ alignSelf: 'center', marginTop: '16px' }}
-              >
-                더보기
-                <img src={moreIcon} alt="moreIcon" />
-              </button>
-            ) : dashboardData.activeProjects.length > 3 ? (
-              <button 
-                className="more-btn" 
-                onClick={() => setVisibleStatusCount(3)} 
-                style={{ alignSelf: 'center', marginTop: '16px' }}
-              >
-                접기
-                <img src={moreIcon} alt="moreIcon" style={{ transform: 'rotate(180deg)' }} />
-              </button>
             ) : null}
           </div>
         </div>

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -126,6 +126,7 @@ function DashboardPage() {
               {dashboardData.projectStatuses.map((project) => (
                 <StatusItem
                   key={project.id}
+                  id={project.id}
                   title={project.title}
                   date={project.date}
                   ratio={project.ratio}

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -8,10 +8,9 @@ import StatusItem from './components/StatusItem';
 // 임시 데이터
 const dummyDashboardData = {
   activeProjects: [
-    { id: 1, title: '캡스톤 디자인', date: '2026.05.08' },
-    { id: 2, title: '팀플 과제', date: '2026.06.01' },
-    { id: 3, title: 'WAP 프로젝트', date: '2026.06.05' },
-
+    { id: 1, title: '캡스톤 디자인', date: '2026.05.08', ratio: '12/18' },
+    { id: 2, title: '팀플 과제', date: '2026.06.01', ratio: '5/10' },
+    { id: 3, title: 'WAP 프로젝트', date: '2026.06.05', ratio: '7/18' },
   ],
   urgentTasks: [
     { id: 1, title: '캡스톤 디자인 - 자료 조사하기', date: '2026.05.05' },
@@ -23,20 +22,6 @@ const dummyDashboardData = {
     { id: 1, title: 'WAP 프로젝트', date: '2025.11.28' },
     { id: 2, title: '팀플 과제', date: '2026.04.01' },
   ],
-  projectStatuses: [
-    {
-      id: 1,
-      title: '캡스톤 디자인',
-      date: '2026.05.08',
-      ratio: '12/18',
-    },
-    {
-      id: 2,
-      title: 'WAP 프로젝트',
-      date: '2027.06.05',
-      ratio: '3/18',
-    },
-  ],
 };
 
 function DashboardPage() {
@@ -44,7 +29,6 @@ function DashboardPage() {
     activeProjects: [],
     urgentTasks: [],
     completedTasks: [],
-    projectStatuses: [],
   });
 
   const [isLoading, setIsLoading] = useState(true);
@@ -124,6 +108,7 @@ function DashboardPage() {
 
             <div className="status-list">
               {dashboardData.projectStatuses.map((project) => (
+              {dashboardData.activeProjects.map((project) => (
                 <StatusItem
                   key={project.id}
                   id={project.id}
@@ -133,6 +118,7 @@ function DashboardPage() {
                 />
               ))}
             </div>
+            ) : null}
           </div>
         </div>
       </div>

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -4,6 +4,7 @@ import Calendar from './components/Calendar';
 import projectMenuIcon from '../../assets/projectMenuIcon.svg';
 import SummaryCard from './components/SummaryCard';
 import StatusItem from './components/StatusItem';
+import moreIcon from '../../assets/moreIcon.svg';
 
 // 임시 데이터
 const dummyDashboardData = {
@@ -33,6 +34,7 @@ function DashboardPage() {
   });
 
   const [isLoading, setIsLoading] = useState(true);
+  const [visibleStatusCount, setVisibleStatusCount] = useState(3);
 
   useEffect(() => {
     // 백엔드 API 연결 시 이 부분 수정
@@ -72,6 +74,10 @@ function DashboardPage() {
     [dashboardData]
   );
 
+  const handleShowMoreStatus = () => {
+    setVisibleStatusCount((prevCount) => prevCount + 3);
+  };
+
   if (isLoading) {
     return (
       <div className="dashboard-container">
@@ -108,7 +114,7 @@ function DashboardPage() {
             </div>
 
             <div className="status-list">
-              {dashboardData.projectStatuses.map((project) => (
+              {dashboardData.projects.slice(0, visibleStatusCount).map((project) => (
                 <StatusItem
                   key={project.id}
                   id={project.id}
@@ -118,6 +124,26 @@ function DashboardPage() {
                 />
               ))}
             </div>
+
+            {visibleStatusCount < dashboardData.projects.length ? (
+              <button 
+                className="more-btn" 
+                onClick={handleShowMoreStatus} 
+                style={{ alignSelf: 'center', marginTop: '16px' }}
+              >
+                더보기
+                <img src={moreIcon} alt="moreIcon" />
+              </button>
+            ) : dashboardData.projects.length > 3 ? (
+              <button 
+                className="more-btn" 
+                onClick={() => setVisibleStatusCount(3)} 
+                style={{ alignSelf: 'center', marginTop: '16px' }}
+              >
+                접기
+                <img src={moreIcon} alt="moreIcon" style={{ transform: 'rotate(180deg)' }} />
+              </button>
+            ) : null}
           </div>
         </div>
       </div>

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -8,9 +8,10 @@ import StatusItem from './components/StatusItem';
 // 임시 데이터
 const dummyDashboardData = {
   activeProjects: [
-    { id: 1, title: '캡스톤 디자인', date: '2026.05.08', ratio: '12/18' },
-    { id: 2, title: '팀플 과제', date: '2026.06.01', ratio: '5/10' },
-    { id: 3, title: 'WAP 프로젝트', date: '2026.06.05', ratio: '7/18' },
+    { id: 1, title: '캡스톤 디자인', date: '2026.05.08' },
+    { id: 2, title: '팀플 과제', date: '2026.06.01' },
+    { id: 3, title: 'WAP 프로젝트', date: '2026.06.05' },
+
   ],
   urgentTasks: [
     { id: 1, title: '캡스톤 디자인 - 자료 조사하기', date: '2026.05.05' },
@@ -22,6 +23,20 @@ const dummyDashboardData = {
     { id: 1, title: 'WAP 프로젝트', date: '2025.11.28' },
     { id: 2, title: '팀플 과제', date: '2026.04.01' },
   ],
+  projectStatuses: [
+    {
+      id: 1,
+      title: '캡스톤 디자인',
+      date: '2026.05.08',
+      ratio: '12/18',
+    },
+    {
+      id: 2,
+      title: 'WAP 프로젝트',
+      date: '2027.06.05',
+      ratio: '3/18',
+    },
+  ],
 };
 
 function DashboardPage() {
@@ -29,6 +44,7 @@ function DashboardPage() {
     activeProjects: [],
     urgentTasks: [],
     completedTasks: [],
+    projectStatuses: [],
   });
 
   const [isLoading, setIsLoading] = useState(true);
@@ -108,7 +124,6 @@ function DashboardPage() {
 
             <div className="status-list">
               {dashboardData.projectStatuses.map((project) => (
-              {dashboardData.activeProjects.map((project) => (
                 <StatusItem
                   key={project.id}
                   id={project.id}
@@ -118,7 +133,6 @@ function DashboardPage() {
                 />
               ))}
             </div>
-            ) : null}
           </div>
         </div>
       </div>

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -7,11 +7,11 @@ import StatusItem from './components/StatusItem';
 
 // 임시 데이터
 const dummyDashboardData = {
-  activeProjects: [
-    { id: 1, title: '캡스톤 디자인', date: '2026.05.08' },
-    { id: 2, title: '팀플 과제', date: '2026.06.01' },
-    { id: 3, title: 'WAP 프로젝트', date: '2026.06.05' },
-
+  projects: [
+    { id: 1, title: '캡스톤 디자인', date: '2026.05.08', ratio: '12/18' },
+    { id: 2, title: '팀플 과제', date: '2026.06.01', ratio: '5/10' },
+    { id: 3, title: 'WAP 프로젝트', date: '2026.06.05', ratio: '3/18' },
+    { id: 4, title: '토이 프로젝트', date: '2026.07.12', ratio: '2/8' },
   ],
   urgentTasks: [
     { id: 1, title: '캡스톤 디자인 - 자료 조사하기', date: '2026.05.05' },
@@ -23,28 +23,13 @@ const dummyDashboardData = {
     { id: 1, title: 'WAP 프로젝트', date: '2025.11.28' },
     { id: 2, title: '팀플 과제', date: '2026.04.01' },
   ],
-  projectStatuses: [
-    {
-      id: 1,
-      title: '캡스톤 디자인',
-      date: '2026.05.08',
-      ratio: '12/18',
-    },
-    {
-      id: 2,
-      title: 'WAP 프로젝트',
-      date: '2027.06.05',
-      ratio: '3/18',
-    },
-  ],
 };
 
 function DashboardPage() {
   const [dashboardData, setDashboardData] = useState({
-    activeProjects: [],
+    projects: [],
     urgentTasks: [],
     completedTasks: [],
-    projectStatuses: [],
   });
 
   const [isLoading, setIsLoading] = useState(true);
@@ -70,7 +55,7 @@ function DashboardPage() {
       {
         id: 1,
         title: '참여 중인 프로젝트',
-        items: dashboardData.activeProjects,
+        items: dashboardData.projects,
         showDot: true,
       },
       {

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -4,7 +4,6 @@ import Calendar from './components/Calendar';
 import projectMenuIcon from '../../assets/projectMenuIcon.svg';
 import SummaryCard from './components/SummaryCard';
 import StatusItem from './components/StatusItem';
-import moreIcon from '../../assets/moreIcon.svg';
 
 // 임시 데이터
 const dummyDashboardData = {
@@ -12,7 +11,6 @@ const dummyDashboardData = {
     { id: 1, title: '캡스톤 디자인', date: '2026.05.08', ratio: '12/18' },
     { id: 2, title: '팀플 과제', date: '2026.06.01', ratio: '5/10' },
     { id: 3, title: 'WAP 프로젝트', date: '2026.06.05', ratio: '7/18' },
-    { id: 4, title: '스터디', date: '2026.07.05', ratio: '3/18' },
   ],
   urgentTasks: [
     { id: 1, title: '캡스톤 디자인 - 자료 조사하기', date: '2026.05.05' },
@@ -34,7 +32,6 @@ function DashboardPage() {
   });
 
   const [isLoading, setIsLoading] = useState(true);
-  const [visibleStatusCount, setVisibleStatusCount] = useState(3);
 
   useEffect(() => {
     // 백엔드 API 연결 시 이 부분 수정
@@ -74,10 +71,6 @@ function DashboardPage() {
     [dashboardData]
   );
 
-  const handleShowMoreStatus = () => {
-    setVisibleStatusCount((prevCount) => prevCount + 3);
-  };
-
   if (isLoading) {
     return (
       <div className="dashboard-container">
@@ -114,7 +107,8 @@ function DashboardPage() {
             </div>
 
             <div className="status-list">
-              {dashboardData.activeProjects.slice(0, visibleStatusCount).map((project) => (
+              {dashboardData.projectStatuses.map((project) => (
+              {dashboardData.activeProjects.map((project) => (
                 <StatusItem
                   key={project.id}
                   id={project.id}
@@ -124,25 +118,6 @@ function DashboardPage() {
                 />
               ))}
             </div>
-
-            {visibleStatusCount < dashboardData.activeProjects.length ? (
-              <button 
-                className="more-btn" 
-                onClick={handleShowMoreStatus} 
-                style={{ alignSelf: 'center', marginTop: '16px' }}
-              >
-                더보기
-                <img src={moreIcon} alt="moreIcon" />
-              </button>
-            ) : dashboardData.activeProjects.length > 3 ? (
-              <button 
-                className="more-btn" 
-                onClick={() => setVisibleStatusCount(3)} 
-                style={{ alignSelf: 'center', marginTop: '16px' }}
-              >
-                접기
-                <img src={moreIcon} alt="moreIcon" style={{ transform: 'rotate(180deg)' }} />
-              </button>
             ) : null}
           </div>
         </div>

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -4,6 +4,7 @@ import Calendar from './components/Calendar';
 import projectMenuIcon from '../../assets/projectMenuIcon.svg';
 import SummaryCard from './components/SummaryCard';
 import StatusItem from './components/StatusItem';
+import moreIcon from '../../assets/moreIcon.svg';
 
 // 임시 데이터
 const dummyDashboardData = {
@@ -11,6 +12,7 @@ const dummyDashboardData = {
     { id: 1, title: '캡스톤 디자인', date: '2026.05.08', ratio: '12/18' },
     { id: 2, title: '팀플 과제', date: '2026.06.01', ratio: '5/10' },
     { id: 3, title: 'WAP 프로젝트', date: '2026.06.05', ratio: '7/18' },
+    { id: 4, title: '스터디', date: '2026.07.05', ratio: '3/18' },
   ],
   urgentTasks: [
     { id: 1, title: '캡스톤 디자인 - 자료 조사하기', date: '2026.05.05' },
@@ -32,6 +34,7 @@ function DashboardPage() {
   });
 
   const [isLoading, setIsLoading] = useState(true);
+  const [visibleStatusCount, setVisibleStatusCount] = useState(3);
 
   useEffect(() => {
     // 백엔드 API 연결 시 이 부분 수정
@@ -71,6 +74,10 @@ function DashboardPage() {
     [dashboardData]
   );
 
+  const handleShowMoreStatus = () => {
+    setVisibleStatusCount((prevCount) => prevCount + 3);
+  };
+
   if (isLoading) {
     return (
       <div className="dashboard-container">
@@ -107,8 +114,7 @@ function DashboardPage() {
             </div>
 
             <div className="status-list">
-              {dashboardData.projectStatuses.map((project) => (
-              {dashboardData.activeProjects.map((project) => (
+              {dashboardData.activeProjects.slice(0, visibleStatusCount).map((project) => (
                 <StatusItem
                   key={project.id}
                   id={project.id}
@@ -118,6 +124,25 @@ function DashboardPage() {
                 />
               ))}
             </div>
+
+            {visibleStatusCount < dashboardData.activeProjects.length ? (
+              <button 
+                className="more-btn" 
+                onClick={handleShowMoreStatus} 
+                style={{ alignSelf: 'center', marginTop: '16px' }}
+              >
+                더보기
+                <img src={moreIcon} alt="moreIcon" />
+              </button>
+            ) : dashboardData.activeProjects.length > 3 ? (
+              <button 
+                className="more-btn" 
+                onClick={() => setVisibleStatusCount(3)} 
+                style={{ alignSelf: 'center', marginTop: '16px' }}
+              >
+                접기
+                <img src={moreIcon} alt="moreIcon" style={{ transform: 'rotate(180deg)' }} />
+              </button>
             ) : null}
           </div>
         </div>

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -4,6 +4,7 @@ import Calendar from './components/Calendar';
 import projectMenuIcon from '../../assets/projectMenuIcon.svg';
 import SummaryCard from './components/SummaryCard';
 import StatusItem from './components/StatusItem';
+import moreIcon from '../../assets/moreIcon.svg';
 
 // 임시 데이터
 const dummyDashboardData = {
@@ -32,6 +33,7 @@ function DashboardPage() {
   });
 
   const [isLoading, setIsLoading] = useState(true);
+  const [visibleStatusCount, setVisibleStatusCount] = useState(3);
 
   useEffect(() => {
     // 백엔드 API 연결 시 이 부분 수정
@@ -71,6 +73,10 @@ function DashboardPage() {
     [dashboardData]
   );
 
+  const handleShowMoreStatus = () => {
+    setVisibleStatusCount((prevCount) => prevCount + 3);
+  };
+
   if (isLoading) {
     return (
       <div className="dashboard-container">
@@ -107,8 +113,7 @@ function DashboardPage() {
             </div>
 
             <div className="status-list">
-              {dashboardData.projectStatuses.map((project) => (
-              {dashboardData.activeProjects.map((project) => (
+              {dashboardData.activeProjects.slice(0, visibleStatusCount).map((project) => (
                 <StatusItem
                   key={project.id}
                   id={project.id}
@@ -118,6 +123,25 @@ function DashboardPage() {
                 />
               ))}
             </div>
+
+            {visibleStatusCount < dashboardData.activeProjects.length ? (
+              <button 
+                className="more-btn" 
+                onClick={handleShowMoreStatus} 
+                style={{ alignSelf: 'center', marginTop: '16px' }}
+              >
+                더보기
+                <img src={moreIcon} alt="moreIcon" />
+              </button>
+            ) : dashboardData.activeProjects.length > 3 ? (
+              <button 
+                className="more-btn" 
+                onClick={() => setVisibleStatusCount(3)} 
+                style={{ alignSelf: 'center', marginTop: '16px' }}
+              >
+                접기
+                <img src={moreIcon} alt="moreIcon" style={{ transform: 'rotate(180deg)' }} />
+              </button>
             ) : null}
           </div>
         </div>

--- a/FE/src/pages/DashboardPage/components/Calendar.css
+++ b/FE/src/pages/DashboardPage/components/Calendar.css
@@ -27,10 +27,6 @@
   gap: 10px;
 }
 
-.calendar-icon {
-  margin-top: 2px;
-}
-
 .calendar-title {
   margin: 0;
   font-family: 'Pretendard';

--- a/FE/src/pages/DashboardPage/components/Calendar.css
+++ b/FE/src/pages/DashboardPage/components/Calendar.css
@@ -6,7 +6,7 @@
   flex: 1.6;
   min-width: 0;
   min-height: 0;
-  padding: 28px 35px;
+  padding: 28px 35px 3px;
   gap: 5px;
   background: #ffffff;
   border-radius: 10px;
@@ -70,7 +70,7 @@
   min-width: 0;
   flex: 1;
   min-height: 0;
-  padding: 13px 0;
+  padding: 11px 0;
   gap: 13px;
   border-top: 1px solid #d9d9d9;
   background: #ffffff;
@@ -100,7 +100,7 @@
 .calendar-grid {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
-  grid-auto-rows: minmax(45px, 1fr);
+  grid-auto-rows: minmax(35px, 1fr);
   width: 100%;
   flex: 1;
   min-height: 0;
@@ -134,7 +134,7 @@
   flex-direction: column;
   align-items: stretch;
   min-width: 0;
-  min-height: 45px;
+  min-height: 35px;
   height: auto;
   padding: 4px 0;
   gap: 2px;
@@ -319,10 +319,11 @@
 
   .calendar-grid {
     grid-auto-rows: minmax(40px, 1fr);
+    grid-auto-rows: minmax(30px, 1fr);
   }
 
   .calendar-cell {
-    min-height: 40px;
+    min-height: 30px;
   }
 
   .calendar-sidebar {

--- a/FE/src/pages/DashboardPage/components/Calendar.css
+++ b/FE/src/pages/DashboardPage/components/Calendar.css
@@ -5,6 +5,7 @@
   width: 100%;
   flex: 1.6;
   min-width: 0;
+  min-height: 0;
   padding: 28px 35px;
   gap: 5px;
   background: #ffffff;
@@ -67,6 +68,8 @@
   align-items: stretch;
   width: 100%;
   min-width: 0;
+  flex: 1;
+  min-height: 0;
   padding: 13px 0;
   gap: 13px;
   border-top: 1px solid #d9d9d9;
@@ -80,6 +83,7 @@
   align-items: stretch;
   flex: 1;
   min-width: 0;
+  min-height: 0;
   padding: 5px 0;
   gap: 5px;
   box-sizing: border-box;
@@ -96,8 +100,10 @@
 .calendar-grid {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
-  grid-auto-rows: minmax(60px, auto);
+  grid-auto-rows: minmax(45px, 1fr);
   width: 100%;
+  flex: 1;
+  min-height: 0;
   overflow: visible;
 }
 
@@ -128,7 +134,7 @@
   flex-direction: column;
   align-items: stretch;
   min-width: 0;
-  min-height: 60px;
+  min-height: 45px;
   height: auto;
   padding: 4px 0;
   gap: 2px;
@@ -312,11 +318,11 @@
   }
 
   .calendar-grid {
-    grid-auto-rows: minmax(50px, auto);
+    grid-auto-rows: minmax(40px, 1fr);
   }
 
   .calendar-cell {
-    min-height: 50px;
+    min-height: 40px;
   }
 
   .calendar-sidebar {

--- a/FE/src/pages/DashboardPage/components/Calendar.css
+++ b/FE/src/pages/DashboardPage/components/Calendar.css
@@ -1,20 +1,19 @@
 .calendar-section {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: 28px 40px;
-  gap: 5px;
-  flex: 1.5;
+  align-items: stretch;
+  width: 100%;
+  flex: 1.6;
   min-width: 0;
-  min-height: 0;
-  background: #FFFFFF;
+  padding: 28px 35px;
+  gap: 5px;
+  background: #ffffff;
   border-radius: 10px;
   box-sizing: border-box;
 }
 
 .calendar-header-row {
   display: flex;
-  flex-direction: row;
   justify-content: space-between;
   align-items: center;
   width: 100%;
@@ -22,14 +21,14 @@
   margin-bottom: 7px;
 }
 
-.icon-calendar{
-  margin-top: 2px;
-}
-
 .calendar-title-group {
   display: flex;
   align-items: center;
   gap: 10px;
+}
+
+.calendar-icon {
+  margin-top: 2px;
 }
 
 .calendar-title {
@@ -48,96 +47,298 @@
 }
 
 .nav-date {
+  margin: 0 4px;
   font-family: 'Pretendard';
   font-weight: 400;
   font-size: 18px;
   color: #909090;
-  margin: 0 4px;
 }
 
 .nav-btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 4px;
   background: none;
   border: none;
-  cursor: pointer;
   color: #909090;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 4px;
+  cursor: pointer;
 }
 
 .calendar-body {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
   width: 100%;
+  min-width: 0;
+  padding: 13px 0;
+  gap: 13px;
+  border-top: 1px solid #d9d9d9;
+  background: #ffffff;
+  box-sizing: border-box;
+}
+
+.calendar-main {
   display: flex;
   flex-direction: column;
-  border-top: 1px solid #D9D9D9;
-  padding-top: 15px;
-  gap: 10px;
+  align-items: stretch;
   flex: 1;
-  min-height: 0;
+  min-width: 0;
+  padding: 5px 0;
+  gap: 5px;
+  box-sizing: border-box;
 }
 
 .calendar-weekdays {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 5px;
-}
-
-.weekday {
-  text-align: center;
-  font-family: 'Pretendard';
-  font-size: 12px;
-  font-weight: 400;
-  color: #000000;
-}
-
-.weekday.sun {
-  color: #DE0000;
-}
-
-.weekday.sat {
-  color: #0300A6;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  width: 100%;
+  height: 14px;
+  flex-shrink: 0;
 }
 
 .calendar-grid {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  grid-template-rows: repeat(6, 1fr);
-  gap: 5px;
-  flex: 1;
-  min-height: 0;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  grid-auto-rows: minmax(60px, auto);
+  width: 100%;
+  overflow: visible;
 }
 
-.calendar-cell {
+.weekday {
   display: flex;
-  justify-content: flex-end;
-  align-items: flex-start;
-  padding: 4px 6px;
-  background: #FFFFFF;
-  border: 0.5px solid #D9D9D9;
-  min-height: 60px;
-  min-width: 0;
-}
-
-.calendar-cell.weekend {
-  background: #F1F1F1;
-}
-
-.calendar-cell.empty {
-  border-color: transparent;
-  background: transparent;
-}
-
-.day-number {
+  justify-content: center;
+  align-items: center;
   font-family: 'Pretendard';
-  font-size: 14px;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 14px;
+  letter-spacing: -0.005em;
   color: #000000;
 }
 
-@media (max-width: 768px) {
+.weekday.sun {
+  color: #de0000;
+}
+
+.weekday.sat {
+  color: #0300a6;
+}
+
+.calendar-cell {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  min-width: 0;
+  min-height: 60px;
+  height: auto;
+  padding: 4px 0;
+  gap: 2px;
+  background: #ffffff;
+  border: 0.5px solid #d9d9d9;
+  box-sizing: border-box;
+  overflow: visible;
+}
+
+.calendar-cell.has-event-start {
+  z-index: 3;
+}
+
+.calendar-cell.has-spanning-event-start {
+  z-index: 5;
+}
+
+.calendar-cell.empty {
+  background: #ffffff;
+}
+
+.day-number {
+  flex-shrink: 0;
+  padding: 0 6px;
+  font-family: 'Pretendard';
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 17px;
+  text-align: right;
+  letter-spacing: -0.005em;
+  color: #000000;
+}
+
+.calendar-event {
+  position: relative;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  min-height: 14px;
+  height: auto;
+  flex-shrink: 0;
+  padding: 1px 6px;
+  background: #ffebde;
+  border-left: 1px solid #ff6600;
+  box-sizing: border-box;
+  font-family: 'Pretendard';
+  font-weight: 600;
+  font-size: 10px;
+  line-height: 12px;
+  letter-spacing: -0.005em;
+  color: #ff6600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.calendar-event.continued {
+  visibility: hidden;
+  pointer-events: none;
+  border-left: none;
+}
+
+.calendar-sidebar {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: stretch;
+  width: 105px;
+  flex-shrink: 0;
+  padding: 5px 0;
+}
+
+.calendar-todo-list {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+  padding: 10px 0;
+  gap: 4px;
+}
+
+.todo-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 32px;
+  padding: 6px;
+  gap: 8px;
+  background: #ffffff;
+  border: none;
+  border-radius: 6px;
+  box-sizing: border-box;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.todo-item:hover {
+  background: #f8f9fa;
+}
+
+.todo-checkbox {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: none;
+  width: 14px;
+  height: 14px;
+  background: #f1f1f1;
+  border: 1px solid #ababab;
+  border-radius: 2px;
+  box-sizing: border-box;
+}
+
+.todo-checkbox.checked {
+  background: #fe9a57;
+  border-color: #fe9a57;
+}
+
+.todo-text {
+  font-family: 'Pretendard';
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 14px;
+  color: #000000;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.add-event-btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 29px;
+  flex-shrink: 0;
+  padding: 6px;
+  gap: 10px;
+  background: #ffebde;
+  border: none;
+  border-radius: 5px;
+  box-sizing: border-box;
+  font-family: 'Pretendard';
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 17px;
+  color: #ff6600;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.add-event-btn:hover {
+  background: #ffe0cc;
+}
+
+@media (max-width: 480px) {
   .calendar-section {
-    padding: 20px 16px;
     flex: 1;
     width: 100%;
+    padding: 20px 16px;
+  }
+
+  .calendar-header-row {
+    height: auto;
+  }
+
+  .calendar-title {
+    font-size: 18px;
+    line-height: 22px;
+  }
+
+  .nav-date {
+    font-size: 16px;
+  }
+
+  .calendar-body {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .calendar-grid {
+    grid-auto-rows: minmax(50px, auto);
+  }
+
+  .calendar-cell {
+    min-height: 50px;
+  }
+
+  .calendar-sidebar {
+    width: 100%;
+    height: auto;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .calendar-todo-list {
+    flex: 1;
+    width: auto;
+    padding: 10px 0;
+  }
+
+  .add-event-btn {
+    width: 105px;
+    align-self: flex-end;
   }
 }

--- a/FE/src/pages/DashboardPage/components/Calendar.jsx
+++ b/FE/src/pages/DashboardPage/components/Calendar.jsx
@@ -1,18 +1,64 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import './Calendar.css';
 import calendarIcon from '../../../assets/CalendarIcon.svg';
 
 const WEEKDAYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 
+const today = new Date();
+const currentYear = today.getFullYear();
+const currentMonth = today.getMonth();
+
+const initialEvents = [
+  {
+    id: 1,
+    text: '회의',
+    start: new Date(currentYear, currentMonth, 6),
+    end: new Date(currentYear, currentMonth, 6),
+    checked: false,
+  },
+  {
+    id: 2,
+    text: '왑 중간 발표',
+    start: new Date(currentYear, currentMonth, 6),
+    end: new Date(currentYear, currentMonth, 7),
+    checked: true,
+  },
+  {
+    id: 3,
+    text: '왑 부스팅 데이',
+    start: new Date(currentYear, currentMonth, 9),
+    end: new Date(currentYear, currentMonth, 9),
+    checked: false,
+  },
+  {
+    id: 4,
+    text: '대동제',
+    start: new Date(currentYear, currentMonth, 12),
+    end: new Date(currentYear, currentMonth, 14),
+    checked: false,
+  },
+  {
+    id: 5,
+    text: '왑 홈커밍 데이',
+    start: new Date(currentYear, currentMonth, 16),
+    end: new Date(currentYear, currentMonth, 16),
+    checked: false,
+  }
+];
+
 function Calendar() {
   const [currentDate, setCurrentDate] = useState(new Date());
+  const [events, setEvents] = useState(initialEvents);
 
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
 
-  // 현재 월의 총 일수와 시작 요일 계산
-  const daysInMonth = new Date(year, month + 1, 0).getDate();
-  const firstDayOfMonth = new Date(year, month, 1).getDay();
+  const days = useMemo(() => getCalendarDays(year, month), [year, month]);
+
+  const visibleEvents = useMemo(
+    () => getVisibleEvents(events, year, month),
+    [events, year, month]
+  );
 
   const handlePrevMonth = () => {
     setCurrentDate(new Date(year, month - 1, 1));
@@ -22,75 +68,284 @@ function Calendar() {
     setCurrentDate(new Date(year, month + 1, 1));
   };
 
-  // 달력 그리드 배열 생성
-  const days = [];
-
-  for (let i = 0; i < firstDayOfMonth; i++) {
-    days.push(null); // 시작일 이전의 빈 칸
-  }
-
-  for (let i = 1; i <= daysInMonth; i++) {
-    days.push(i);
-  }
+  const handleToggleTodo = (id) => {
+    setEvents((prevEvents) =>
+      prevEvents.map((event) =>
+        event.id === id ? { ...event, checked: !event.checked } : event
+      )
+    );
+  };
 
   return (
-    <div className="calendar-section">
+    <section className="calendar-section">
       <div className="calendar-header-row">
         <div className="calendar-title-group">
-          <span className="icon-calendar">
-            <img src={calendarIcon} alt="캘린더 아이콘" />
-          </span>
+          <img
+            className="calendar-icon"
+            src={calendarIcon}
+            alt="캘린더 아이콘"
+          />
           <h2 className="calendar-title">캘린더</h2>
         </div>
 
         <div className="calendar-nav">
-          <button className="nav-btn" onClick={handlePrevMonth}>
+          <button className="nav-btn" type="button" onClick={handlePrevMonth}>
             &lt;
           </button>
 
           <span className="nav-date">
-            {`${year}.${String(month + 1).padStart(2, '0')}`}
+            {year}.{String(month + 1).padStart(2, '0')}
           </span>
 
-          <button className="nav-btn" onClick={handleNextMonth}>
+          <button className="nav-btn" type="button" onClick={handleNextMonth}>
             &gt;
           </button>
         </div>
       </div>
 
       <div className="calendar-body">
-        <div className="calendar-weekdays">
-          {WEEKDAYS.map((day, index) => (
-            <div
-              key={day}
-              className={`weekday ${
-                index === 0 ? 'sun' : index === 6 ? 'sat' : ''
-              }`}
-            >
-              {day}
-            </div>
-          ))}
-        </div>
-
-        <div className="calendar-grid">
-          {days.map((day, index) => {
-            const isWeekend = index % 7 === 0 || index % 7 === 6;
-
-            return (
+        <div className="calendar-main">
+          <div className="calendar-weekdays">
+            {WEEKDAYS.map((day, index) => (
               <div
-                key={index}
-                className={`calendar-cell ${isWeekend ? 'weekend' : ''} ${
-                  !day ? 'empty' : ''
+                key={day}
+                className={`weekday ${index === 0 ? 'sun' : ''} ${
+                  index === 6 ? 'sat' : ''
                 }`}
               >
-                {day && <span className="day-number">{day}</span>}
+                {day}
               </div>
-            );
-          })}
+            ))}
+          </div>
+
+          <div className="calendar-grid">
+            {days.map((day, index) => {
+              const dayEvents = day
+                ? getEventsByDay(events, year, month, day)
+                : [];
+
+              const hasStartEvent = dayEvents.some((event) =>
+                isEventSegmentStart(event, year, month, day, index)
+              );
+
+              const hasSpanningEventStart = dayEvents.some((event) => {
+                const isSegmentStart = isEventSegmentStart(
+                  event,
+                  year,
+                  month,
+                  day,
+                  index
+                );
+
+                const eventSpan = getEventSpan(
+                  event,
+                  year,
+                  month,
+                  day,
+                  index
+                );
+
+                return isSegmentStart && eventSpan > 1;
+              });
+
+              return (
+                <div
+                  key={`calendar-cell-${index}`}
+                  className={`calendar-cell ${!day ? 'empty' : ''} ${
+                    hasStartEvent ? 'has-event-start' : ''
+                  } ${
+                    hasSpanningEventStart ? 'has-spanning-event-start' : ''
+                  }`}
+                >
+                  {day && <span className="day-number">{day}</span>}
+
+                  {dayEvents.map((event) => {
+                    const isSegmentStart = isEventSegmentStart(
+                      event,
+                      year,
+                      month,
+                      day,
+                      index
+                    );
+
+                    const eventSpan = getEventSpan(
+                      event,
+                      year,
+                      month,
+                      day,
+                      index
+                    );
+
+                    return (
+                      <div
+                        key={`${event.id}-${index}`}
+                        className={`calendar-event ${
+                          !isSegmentStart ? 'continued' : ''
+                        }`}
+                        style={
+                          isSegmentStart
+                            ? {
+                                width: `calc(${eventSpan * 100}% + ${
+                                  eventSpan - 1
+                                }px)`,
+                              }
+                            : undefined
+                        }
+                      >
+                        {isSegmentStart ? event.text : ''}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
         </div>
+
+        <aside className="calendar-sidebar">
+          <div className="calendar-todo-list">
+            {visibleEvents.map((event) => (
+              <button
+                key={event.id}
+                className="todo-item"
+                type="button"
+                onClick={() => handleToggleTodo(event.id)}
+              >
+                <span
+                  className={`todo-checkbox ${
+                    event.checked ? 'checked' : ''
+                  }`}
+                >
+                  {event.checked && (
+                    <svg
+                      width="8"
+                      height="6"
+                      viewBox="0 0 8 6"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M1 3L3 5L7 1"
+                        stroke="white"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
+                </span>
+
+                <span className="todo-text">{event.text}</span>
+              </button>
+            ))}
+          </div>
+
+          <button className="add-event-btn" type="button">
+            + 일정 추가
+          </button>
+        </aside>
       </div>
-    </div>
+    </section>
   );
+}
+
+function getCalendarDays(year, month) {
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const firstDayOfMonth = new Date(year, month, 1).getDay();
+
+  const days = [
+    ...Array(firstDayOfMonth).fill(null),
+    ...Array.from({ length: daysInMonth }, (_, index) => index + 1),
+  ];
+
+  const remainder = days.length % 7;
+
+  if (remainder === 0) {
+    return days;
+  }
+
+  return [...days, ...Array(7 - remainder).fill(null)];
+}
+
+function getEventsByDay(events, year, month, day) {
+  const currentDate = new Date(year, month, day).getTime();
+
+  return events
+    .filter(
+      (event) =>
+        currentDate >= event.start.getTime() &&
+        currentDate <= event.end.getTime()
+    )
+    .sort((a, b) => {
+      const aDuration = a.end.getTime() - a.start.getTime();
+      const bDuration = b.end.getTime() - b.start.getTime();
+
+      if (aDuration !== bDuration) {
+        return bDuration - aDuration;
+      }
+
+      const startDiff = a.start.getTime() - b.start.getTime();
+
+      if (startDiff !== 0) {
+        return startDiff;
+      }
+
+      return a.id - b.id;
+    });
+}
+
+function isEventSegmentStart(event, year, month, day, index) {
+  const currentDate = new Date(year, month, day).getTime();
+
+  return (
+    currentDate === event.start.getTime() ||
+    day === 1 ||
+    index % 7 === 0
+  );
+}
+
+function getEventSpan(event, year, month, day, index) {
+  const currentDate = new Date(year, month, day).getTime();
+
+  if (
+    currentDate !== event.start.getTime() &&
+    day !== 1 &&
+    index % 7 !== 0
+  ) {
+    return 1;
+  }
+
+  const daysUntilWeekEnd = 7 - (index % 7);
+  const lastDayOfMonth = new Date(year, month + 1, 0).getDate();
+
+  const eventEndDay =
+    event.end.getFullYear() === year && event.end.getMonth() === month
+      ? event.end.getDate()
+      : lastDayOfMonth;
+
+  const remainingEventDays = eventEndDay - day + 1;
+
+  return Math.min(daysUntilWeekEnd, remainingEventDays);
+}
+
+function getVisibleEvents(events, year, month) {
+  const monthStart = new Date(year, month, 1).getTime();
+  const monthEnd = new Date(year, month + 1, 0).getTime();
+
+  return events
+    .filter(
+      (event) =>
+        event.start.getTime() <= monthEnd && event.end.getTime() >= monthStart
+    )
+    .sort((a, b) => {
+      const startDiff = a.start.getTime() - b.start.getTime();
+
+      if (startDiff !== 0) {
+        return startDiff;
+      }
+
+      return a.id - b.id;
+    });
 }
 
 export default Calendar;

--- a/FE/src/pages/DashboardPage/components/Calendar.jsx
+++ b/FE/src/pages/DashboardPage/components/Calendar.jsx
@@ -43,7 +43,7 @@ const initialEvents = [
     start: new Date(currentYear, currentMonth, 16),
     end: new Date(currentYear, currentMonth, 16),
     checked: false,
-  }
+  },
 ];
 
 function Calendar() {
@@ -185,6 +185,7 @@ function Calendar() {
                         style={
                           isSegmentStart
                             ? {
+                                // 이어지는 일정은 시작 칸에서만 너비를 확장
                                 width: `calc(${eventSpan * 100}% + ${
                                   eventSpan - 1
                                 }px)`,
@@ -264,6 +265,7 @@ function getCalendarDays(year, month) {
     return days;
   }
 
+  // 마지막 주도 7칸 구조를 유지하도록 빈 칸을 추가
   return [...days, ...Array(7 - remainder).fill(null)];
 }
 
@@ -280,6 +282,7 @@ function getEventsByDay(events, year, month, day) {
       const aDuration = a.end.getTime() - a.start.getTime();
       const bDuration = b.end.getTime() - b.start.getTime();
 
+      // 긴 일정이 위에 오도록 정렬
       if (aDuration !== bDuration) {
         return bDuration - aDuration;
       }
@@ -297,6 +300,7 @@ function getEventsByDay(events, year, month, day) {
 function isEventSegmentStart(event, year, month, day, index) {
   const currentDate = new Date(year, month, day).getTime();
 
+  // 일정 시작일이 아니어도 월 첫날이나 주 첫날이면 새 구간으로 다시 표시
   return (
     currentDate === event.start.getTime() ||
     day === 1 ||
@@ -325,6 +329,7 @@ function getEventSpan(event, year, month, day, index) {
 
   const remainingEventDays = eventEndDay - day + 1;
 
+  // 일정이 현재 주 안에서 차지할 칸 수만 계산
   return Math.min(daysUntilWeekEnd, remainingEventDays);
 }
 

--- a/FE/src/pages/DashboardPage/components/StatusItem.css
+++ b/FE/src/pages/DashboardPage/components/StatusItem.css
@@ -81,7 +81,8 @@
 }
 
 .progress-percent {
-  font-weight: 500;
-  font-size: 26px;
+  font-family: 'YSpotlightOTF';
+  font-weight: 100;
+  font-size: 25px;
   color: #FF6600;
 }

--- a/FE/src/pages/DashboardPage/components/StatusItem.css
+++ b/FE/src/pages/DashboardPage/components/StatusItem.css
@@ -81,8 +81,7 @@
 }
 
 .progress-percent {
-  font-family: 'YSpotlightOTF';
-  font-weight: 100;
-  font-size: 25px;
+  font-weight: 500;
+  font-size: 26px;
   color: #FF6600;
 }

--- a/FE/src/pages/DashboardPage/components/StatusItem.css
+++ b/FE/src/pages/DashboardPage/components/StatusItem.css
@@ -2,6 +2,14 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  cursor: pointer;
+  padding: 12px;
+  border-radius: 8px;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.status-item:hover {
+  background-color: #f8f9fa;
 }
 
 .status-info-row {

--- a/FE/src/pages/DashboardPage/components/StatusItem.css
+++ b/FE/src/pages/DashboardPage/components/StatusItem.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: 12px;
   cursor: pointer;
-  padding: 12px;
+  padding: 10px;
   border-radius: 8px;
   transition: background-color 0.2s ease-in-out;
 }

--- a/FE/src/pages/DashboardPage/components/StatusItem.jsx
+++ b/FE/src/pages/DashboardPage/components/StatusItem.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import './StatusItem.css';
 import Avatar from '../../../components/Avatar/Avatar';
@@ -7,19 +7,16 @@ import { getDiffDays } from '../components/DateUtils';
 
 function StatusItem({ id, title, date = '', tag = '여유', ratio }) {
   const navigate = useNavigate();
-
-  const progressValue = useMemo(() => {
-    if (ratio && ratio.includes('/')) {
-      const [current, total] = ratio.split('/').map(Number);
-      if (total > 0 && !isNaN(current)) {
-        return Math.round((current / total) * 100);
-      }
+  let progressValue = 0;
+  
+  if (ratio && ratio.includes('/')) {
+    const [current, total] = ratio.split('/').map(Number);
+    if (total > 0 && !isNaN(current)) {
+      progressValue = Math.round((current / total) * 100);
     }
-    return 0;
-  }, [ratio]);
+  }
 
-  const diffDays = useMemo(() => getDiffDays(date), [date]);
-  const isUrgent = diffDays < 7;
+  const diffDays = getDiffDays(date);
 
   return (
     <div 
@@ -38,8 +35,8 @@ function StatusItem({ id, title, date = '', tag = '여유', ratio }) {
           </div>
         </div>
 
-        <div className={`status-tag ${isUrgent ? 'urgent' : ''}`}>
-          {isUrgent ? '긴급' : tag}
+        <div className={`status-tag ${diffDays < 7 ? 'urgent' : ''}`}>
+          {diffDays < 7 ? '긴급' : tag}
         </div>
       </div>
 

--- a/FE/src/pages/DashboardPage/components/StatusItem.jsx
+++ b/FE/src/pages/DashboardPage/components/StatusItem.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import './StatusItem.css';
 import Avatar from '../../../components/Avatar/Avatar';
@@ -7,16 +7,19 @@ import { getDiffDays } from '../components/DateUtils';
 
 function StatusItem({ id, title, date = '', tag = '여유', ratio }) {
   const navigate = useNavigate();
-  let progressValue = 0;
-  
-  if (ratio && ratio.includes('/')) {
-    const [current, total] = ratio.split('/').map(Number);
-    if (total > 0 && !isNaN(current)) {
-      progressValue = Math.round((current / total) * 100);
-    }
-  }
 
-  const diffDays = getDiffDays(date);
+  const progressValue = useMemo(() => {
+    if (ratio && ratio.includes('/')) {
+      const [current, total] = ratio.split('/').map(Number);
+      if (total > 0 && !isNaN(current)) {
+        return Math.round((current / total) * 100);
+      }
+    }
+    return 0;
+  }, [ratio]);
+
+  const diffDays = useMemo(() => getDiffDays(date), [date]);
+  const isUrgent = diffDays < 7;
 
   return (
     <div 
@@ -35,8 +38,8 @@ function StatusItem({ id, title, date = '', tag = '여유', ratio }) {
           </div>
         </div>
 
-        <div className={`status-tag ${diffDays < 7 ? 'urgent' : ''}`}>
-          {diffDays < 7 ? '긴급' : tag}
+        <div className={`status-tag ${isUrgent ? 'urgent' : ''}`}>
+          {isUrgent ? '긴급' : tag}
         </div>
       </div>
 

--- a/FE/src/pages/DashboardPage/components/StatusItem.jsx
+++ b/FE/src/pages/DashboardPage/components/StatusItem.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import './StatusItem.css';
 import Avatar from '../../../components/Avatar/Avatar';
 import ProgressBar from '../../../components/ProgressBar/ProgressBar';
 import { getDiffDays } from '../components/DateUtils';
 
-function StatusItem({ title, date = '', tag = '여유', ratio }) {
+function StatusItem({ id, title, date = '', tag = '여유', ratio }) {
+  const navigate = useNavigate();
   let progressValue = 0;
   
   if (ratio && ratio.includes('/')) {
@@ -17,7 +19,10 @@ function StatusItem({ title, date = '', tag = '여유', ratio }) {
   const diffDays = getDiffDays(date);
 
   return (
-    <div className="status-item">
+    <div 
+      className="status-item"
+      onClick={() => navigate(`/project/${id}`)}
+    >
       <div className="status-info-row">
         <div className="status-left">
           <div className="logo-placeholder">

--- a/FE/src/pages/DashboardPage/components/SummaryCard.css
+++ b/FE/src/pages/DashboardPage/components/SummaryCard.css
@@ -45,9 +45,9 @@
 }
 
 .count-number {
-  font-family: 'YSpotlightOTF';
-  font-weight: 100;
-  font-size: 24px;
+  font-family: 'Pretendard';
+  font-weight: 500;
+  font-size: 28px;
   color: #FF6600;
   margin-right: 4px;
 }

--- a/FE/src/pages/DashboardPage/components/SummaryCard.css
+++ b/FE/src/pages/DashboardPage/components/SummaryCard.css
@@ -65,6 +65,10 @@
   display: flex;
   align-items: center;
   gap: 10px;
+  &:hover {
+    background-color: #f8f9fa;
+    border-radius: 8px;
+  }
 }
 
 .item-dot {

--- a/FE/src/pages/DashboardPage/components/SummaryCard.css
+++ b/FE/src/pages/DashboardPage/components/SummaryCard.css
@@ -45,8 +45,9 @@
 }
 
 .count-number {
-  font-weight: 500;
-  font-size: 28px;
+  font-family: 'YSpotlightOTF';
+  font-weight: 100;
+  font-size: 24px;
   color: #FF6600;
   margin-right: 4px;
 }
@@ -65,10 +66,6 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  &:hover {
-    background-color: #f8f9fa;
-    border-radius: 8px;
-  }
 }
 
 .item-dot {

--- a/FE/src/pages/DashboardPage/components/SummaryCard.jsx
+++ b/FE/src/pages/DashboardPage/components/SummaryCard.jsx
@@ -4,7 +4,7 @@ import './SummaryCard.css';
 import { getDiffDays } from '../components/DateUtils';
 
 function SummaryCard({ title, count, items = [], showDot }) {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(() => window.innerWidth > 768);
   const [visibleCount, setVisibleCount] = useState(3);
 
   //카드 헤더 클릭 시 리스트를 접거나 펼쳐짐, 접을 때 표시 개수를 초기값으로 리셋

--- a/FE/src/pages/DashboardPage/components/SummaryCard.jsx
+++ b/FE/src/pages/DashboardPage/components/SummaryCard.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import moreIcon from '../../../assets/moreIcon.svg';
 import './SummaryCard.css';
 import { getDiffDays } from '../components/DateUtils';
@@ -6,6 +7,8 @@ import { getDiffDays } from '../components/DateUtils';
 function SummaryCard({ title, count, items = [], showDot }) {
   const [isExpanded, setIsExpanded] = useState(() => window.innerWidth > 768);
   const [visibleCount, setVisibleCount] = useState(3);
+  
+  const navigate = useNavigate();
 
   //카드 헤더 클릭 시 리스트를 접거나 펼쳐짐, 접을 때 표시 개수를 초기값으로 리셋
   const toggleExpand = () => {
@@ -47,7 +50,12 @@ function SummaryCard({ title, count, items = [], showDot }) {
         <>
           <ul className="summary-list">
             {visibleItems.map((item) => (
-              <li key={item.id} className="summary-item">
+              <li 
+                key={item.id} 
+                className="summary-item"
+                onClick={() => navigate(`/project/${item.id}`)}
+                style={{ cursor: 'pointer' }}
+              >
                 {showDot && (
                   <span
                     className="item-dot"


### PR DESCRIPTION
## 📌 개요
대시보드 페이지의 레이아웃을 정리하고, 프로젝트 라우팅과 캘린더 UI를 개선했습니다.

## ⚙️ 작업 내용
- 모바일 화면에서 요약카드 기본 접힘 상태 적용
- 프로젝트 클릭 시 임시 라우팅 설정
- 대시보드 불필요한 스크롤 제거 (요약카드 다 접은 상태로는 스크롤 x)
- 캘린더 일정 표시 방식 추가 및 UI 개선
  - css 전면 수정
  - 일정 표시 로직 및 디자인 추가
- "참여중인 프로젝트"와 "프로젝트 현황"의 리스트 통합 
### pc 수정 전
<img width="1300" alt="스크린샷 2026-05-02 183542" src="https://github.com/user-attachments/assets/d6cd7736-afc8-47e6-b376-1f999e7eb60b" />

### pc 수정 후 
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/346f1cad-492e-4f5b-ba75-d1c00c392ef7" />

### 모바일, 수정 전 ==> 수정 후
<img width="300" alt="스크린샷 2026-05-02 183602" src="https://github.com/user-attachments/assets/8409a18f-4b0b-430f-82c8-a9cd00165e86" />
==>
<img width="300" alt="image" src="https://github.com/user-attachments/assets/4e6e91ae-af1c-44b3-b0de-e0eb48fde140" />

 
## 🎸 기타사항
아직 '일정 추가' 모달 구현 전이라, '일정 추가' 버튼 작동 안 하는 점 참고해주세요.
