### PR TITLE
[fix] 카카오 로그인 API 요청 및 콜백 처리 수정

### DIFF
--- a/FE/src/api/authApi.js
+++ b/FE/src/api/authApi.js
@@ -1,7 +1,9 @@
 const baseUrl = import.meta.env.VITE_API_BASE_URL;
 
 export async function getKakaoLoginUrl() {
-  const response = await fetch(`${baseUrl}/api/auth/kakao/login`);
+  const response = await fetch(`${baseUrl}/api/auth/kakao/login`, {
+    credentials: "include",
+  });
 
   const result = await response.json();
 
@@ -19,7 +21,10 @@ export async function requestKakaoLogin(code, state) {
   }).toString();
 
   const response = await fetch(
-    `${baseUrl}/api/auth/kakao/callback?${queryString}`
+    `${baseUrl}/api/auth/kakao/callback?${queryString}`,
+    {
+      credentials: "include",
+    }
   );
 
   if (!response.ok) {

--- a/FE/src/pages/AuthCallback/AuthCallback.jsx
+++ b/FE/src/pages/AuthCallback/AuthCallback.jsx
@@ -10,17 +10,9 @@ export default function AuthCallback() {
   useEffect(() => {
     const code = searchParams.get("code");
     const state = searchParams.get("state");
-    const savedState = localStorage.getItem("oauth_state");
 
     if (!code) {
       console.error("인가 코드가 없습니다.");
-      navigate("/login");
-      return;
-    }
-
-    if (state !== savedState) {
-      console.error("비정상적인 접근입니다. (state 불일치)");
-      alert("로그인에 실패했습니다. 다시 시도해주세요.");
       navigate("/login");
       return;
     }


### PR DESCRIPTION
## 📌 개요
카카오 로그인 요청 경로를 백엔드 API 형식에 맞게 수정하고, 콜백 처리 과정에서 불필요한 프론트 state 검증 로직을 제거했습니다.

## ⚙️ 작업 내용
- 카카오 로그인/콜백 API 요청 경로 수정
- API 요청에 credentials: "include" 옵션 추가
- 프론트단 OAuth state 검증 로직 제거
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
