### PR TITLE
[feat] 공통 - 로그인 후처리 적용

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -11,7 +11,8 @@
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^7.13.1"
+        "react-router-dom": "^7.13.1",
+        "zustand": "^5.0.13"
       },
       "devDependencies": {
         "@babel/core": "^7.29.0",
@@ -920,7 +921,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1214,7 +1215,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2716,6 +2717,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/FE/package.json
+++ b/FE/package.json
@@ -13,7 +13,8 @@
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.13.1"
+    "react-router-dom": "^7.13.1",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/FE/src/api/authApi.js
+++ b/FE/src/api/authApi.js
@@ -19,10 +19,7 @@ export async function requestKakaoLogin(code, state) {
   }).toString();
 
   const response = await fetch(
-    `${baseUrl}/api/auth/kakao/callback?${queryString}`,
-    {
-      credentials: "include",
-    }
+    `${baseUrl}/api/auth/kakao/callback?${queryString}`
   );
 
   if (!response.ok) {

--- a/FE/src/api/authApi.js
+++ b/FE/src/api/authApi.js
@@ -19,7 +19,10 @@ export async function requestKakaoLogin(code, state) {
   }).toString();
 
   const response = await fetch(
-    `${baseUrl}/api/auth/kakao/callback?${queryString}`
+    `${baseUrl}/api/auth/kakao/callback?${queryString}`,
+    {
+      credentials: "include",
+    }
   );
 
   if (!response.ok) {

--- a/FE/src/pages/AuthCallback/AuthCallback.jsx
+++ b/FE/src/pages/AuthCallback/AuthCallback.jsx
@@ -36,7 +36,12 @@ export default function AuthCallback() {
       try {
         const data = await requestKakaoLogin(code, state);
         if (data) {
-          login(data.accessToken, data.refreshToken);
+          login(data.accessToken);
+
+          if (data.profileCompleted === false) {
+            navigate("/profile-setup");
+            return;
+          }
         }
         localStorage.removeItem("oauth_state");
         navigate("/dashboard");

--- a/FE/src/pages/AuthCallback/AuthCallback.jsx
+++ b/FE/src/pages/AuthCallback/AuthCallback.jsx
@@ -36,12 +36,7 @@ export default function AuthCallback() {
       try {
         const data = await requestKakaoLogin(code, state);
         if (data) {
-          login(data.accessToken);
-
-          if (data.profileCompleted === false) {
-            navigate("/profile-setup");
-            return;
-          }
+          login(data.accessToken, data.refreshToken);
         }
         localStorage.removeItem("oauth_state");
         navigate("/dashboard");

--- a/FE/src/pages/AuthCallback/AuthCallback.jsx
+++ b/FE/src/pages/AuthCallback/AuthCallback.jsx
@@ -12,17 +12,9 @@ export default function AuthCallback() {
   useEffect(() => {
     const code = searchParams.get("code");
     const state = searchParams.get("state");
-    const savedState = localStorage.getItem("oauth_state");
 
     if (!code) {
       console.error("인가 코드가 없습니다.");
-      navigate("/login");
-      return;
-    }
-
-    if (state !== savedState) {
-      console.error("비정상적인 접근입니다. (state 불일치)");
-      alert("로그인에 실패했습니다. 다시 시도해주세요.");
       navigate("/login");
       return;
     }
@@ -43,7 +35,6 @@ export default function AuthCallback() {
             return;
           }
         }
-        localStorage.removeItem("oauth_state");
         navigate("/dashboard");
       } catch (err) {
         console.error("카카오 로그인 처리 실패:", err);

--- a/FE/src/pages/AuthCallback/AuthCallback.jsx
+++ b/FE/src/pages/AuthCallback/AuthCallback.jsx
@@ -1,11 +1,13 @@
 import { useEffect, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { requestKakaoLogin } from "../../api/authApi";
+import { useAuthStore } from "../../store/authStore";
 
 export default function AuthCallback() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const isRequesting = useRef(false);
+  const login = useAuthStore((state) => state.login);
 
   useEffect(() => {
     const code = searchParams.get("code");
@@ -34,12 +36,7 @@ export default function AuthCallback() {
       try {
         const data = await requestKakaoLogin(code, state);
         if (data) {
-          if (data.accessToken) {
-            localStorage.setItem("accessToken", data.accessToken);
-          }
-          if (data.refreshToken) {
-            localStorage.setItem("refreshToken", data.refreshToken);
-          }
+          login(data.accessToken, data.refreshToken);
         }
         localStorage.removeItem("oauth_state");
         navigate("/dashboard");

--- a/FE/src/pages/AuthCallback/AuthCallback.jsx
+++ b/FE/src/pages/AuthCallback/AuthCallback.jsx
@@ -33,11 +33,16 @@ export default function AuthCallback() {
 
       try {
         const data = await requestKakaoLogin(code, state);
-        if (data && data.accessToken) {
-          localStorage.setItem("accessToken", data.accessToken);
+        if (data) {
+          if (data.accessToken) {
+            localStorage.setItem("accessToken", data.accessToken);
+          }
+          if (data.refreshToken) {
+            localStorage.setItem("refreshToken", data.refreshToken);
+          }
         }
         localStorage.removeItem("oauth_state");
-        navigate("/");
+        navigate("/dashboard");
       } catch (err) {
         console.error("카카오 로그인 처리 실패:", err);
         alert(err.message || "로그인 처리 중 오류가 발생했습니다.");

--- a/FE/src/pages/AuthCallback/AuthCallback.jsx
+++ b/FE/src/pages/AuthCallback/AuthCallback.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { requestKakaoLogin } from "../../api/authApi";
-import { useAuthStore } from "../../store/authStore";
+import { useAuthStore } from "./authStore.js";
 
 export default function AuthCallback() {
   const navigate = useNavigate();

--- a/FE/src/pages/AuthCallback/authStore.js
+++ b/FE/src/pages/AuthCallback/authStore.js
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+export const useAuthStore = create((set) => ({
+  isLoggedIn: !!localStorage.getItem("accessToken"),
+  login: (accessToken, refreshToken) => {
+    if (accessToken) localStorage.setItem("accessToken", accessToken);
+    if (refreshToken) localStorage.setItem("refreshToken", refreshToken);
+    set({ isLoggedIn: true });
+  },
+  logout: () => {
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
+    set({ isLoggedIn: false });
+  },
+}));

--- a/FE/src/pages/AuthCallback/authStore.js
+++ b/FE/src/pages/AuthCallback/authStore.js
@@ -2,12 +2,14 @@ import { create } from "zustand";
 
 export const useAuthStore = create((set) => ({
   isLoggedIn: !!localStorage.getItem("accessToken"),
-  login: (accessToken) => {
+  login: (accessToken, refreshToken) => {
     if (accessToken) localStorage.setItem("accessToken", accessToken);
+    if (refreshToken) localStorage.setItem("refreshToken", refreshToken);
     set({ isLoggedIn: true });
   },
   logout: () => {
     localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
     set({ isLoggedIn: false });
   },
 }));

--- a/FE/src/pages/AuthCallback/authStore.js
+++ b/FE/src/pages/AuthCallback/authStore.js
@@ -2,14 +2,12 @@ import { create } from "zustand";
 
 export const useAuthStore = create((set) => ({
   isLoggedIn: !!localStorage.getItem("accessToken"),
-  login: (accessToken, refreshToken) => {
+  login: (accessToken) => {
     if (accessToken) localStorage.setItem("accessToken", accessToken);
-    if (refreshToken) localStorage.setItem("refreshToken", refreshToken);
     set({ isLoggedIn: true });
   },
   logout: () => {
     localStorage.removeItem("accessToken");
-    localStorage.removeItem("refreshToken");
     set({ isLoggedIn: false });
   },
 }));


### PR DESCRIPTION
## 📌 개요
카카오 로그인 성공 후 토큰 저장 및 대시보드 이동 로직을 적용했습니다.

## ⚙️ 작업 내용
- 카카오 로그인 성공 시 accessToken 저장 처리
- Zustand를 이용한 로그인 상태 관리 적용
- 로그인 성공 후 대시보드 이동 처리
- 백엔드 응답 구조 변경 반영
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
