### PR TITLE
[fix] 로그인 페이지 - 카카오 로그인 버튼 링크 구조 수정

### DIFF
--- a/FE/src/pages/LoginPage/LoginPage.css
+++ b/FE/src/pages/LoginPage/LoginPage.css
@@ -108,6 +108,8 @@ body,
   border-radius: 5px;
   background: #fee500;
   cursor: pointer;
+  text-decoration: none;
+  color: inherit;
 }
 
 .kakao-login-btn:hover {
@@ -143,6 +145,7 @@ body,
   line-height: 1;
   color: #371d1e;
   white-space: nowrap;
+  
 }
 
 @media (max-width: 414px) {

--- a/FE/src/pages/LoginPage/LoginPage.jsx
+++ b/FE/src/pages/LoginPage/LoginPage.jsx
@@ -4,8 +4,6 @@ import LoginLogo from "./components/LoginLogo";
 import LoginForm from "./components/LoginForm";
 import { getKakaoLoginUrl } from "../../api/kakaoAuthApi.js";
 
-const baseUrl = import.meta.env.VITE_API_BASE_URL;
-
 function LoginPage() {
   const [isLoading, setIsLoading] = useState(false);
 
@@ -26,7 +24,6 @@ function LoginPage() {
     <main className="login-page">
       <section className="login-card">
         <LoginLogo />
-        <a href={`${baseUrl}/api/auth/kakao/login`}>카카오 로그인</a>
         <LoginForm onLogin={kakaoHandleLogin} isLoading={isLoading} />
       </section>
     </main>

--- a/FE/src/pages/LoginPage/components/LoginForm.jsx
+++ b/FE/src/pages/LoginPage/components/LoginForm.jsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import kakaoLogo from "../../../assets/kakao_logo.svg";
 
+const baseUrl = import.meta.env.VITE_API_BASE_URL;
+
 function LoginForm({ onLogin, isLoading }) {
   const [keepLogin, setKeepLogin] = useState(false);
 
@@ -11,15 +13,18 @@ function LoginForm({ onLogin, isLoading }) {
 
   return (
     <form className="login-form" onSubmit={handleSubmit}>
-      <button type="submit" className="kakao-login-btn" disabled={isLoading}>
+      <a
+        href={`${baseUrl}/api/auth/kakao/login`}
+        className="kakao-login-btn"
+      >
         <span className="kakao-login-content">
           <img src={kakaoLogo} alt="카카오 로고" className="kakao-icon" />
 
           <span className="kakao-login-text">
-            {isLoading ? "로그인 연결 중..." : "카카오 로그인으로 시작"}
+            카카오 로그인으로 시작
           </span>
         </span>
-      </button>
+      </a>
     </form>
   );
 }


### PR DESCRIPTION
## 📌 개요
임시로 추가했던 로그인 링크 구조를 정리하고, 버튼 자체가 백엔드 카카오 로그인 엔드포인트로 이동하도록 수정했습니다.

## ⚙️ 작업 내용
- 테스트용 링크 제거
- 카카오 로그인 버튼을 `a` 태그 구조로 변경 및 링크 추가

 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
