### PR TITLE
[feat] 프로젝트 페이지 - UI 구현

### DIFF
--- a/FE/src/App.jsx
+++ b/FE/src/App.jsx
@@ -9,6 +9,7 @@ import AuthCallback from "./pages/AuthCallback/AuthCallback.jsx";
 import TeammakingPage from "./pages/Teammaking/TeammakingPage.jsx";
 import FindTeamPage from "./pages/FindTeam/FindTeamPage.jsx";
 import DashboardPage from "./pages/DashboardPage/DashboardPage.jsx";
+import ProjectPage from "./pages/ProjectPage/ProjectPage.jsx";
 
 function AppLayout({ isMenuOpen, toggleMenu, closeMenu }) {
   return (
@@ -56,6 +57,7 @@ function App() {
           <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/teammaking" element={<TeammakingPage />} />
           <Route path="/find-team" element={<FindTeamPage />} />
+          <Route path="/project" element={<ProjectPage />} />
          
           <Route path="*" element={<ComingSoonPage />} />
         </Route>

--- a/FE/src/components/ProgressBar/ProgressBar.css
+++ b/FE/src/components/ProgressBar/ProgressBar.css
@@ -1,6 +1,6 @@
 .progress-bar {
   width: 100%;
-  max-width: 700px;
+  max-width: 915px;
 
   height: 8px;
   background-color: #F1F1F1;

--- a/FE/src/components/ProjectAvatar/ProjectAvatar.css
+++ b/FE/src/components/ProjectAvatar/ProjectAvatar.css
@@ -7,7 +7,7 @@
   order: 0;
   flex-grow: 0;
   position: relative;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;

--- a/FE/src/pages/ProjectPage/ProjectPage.css
+++ b/FE/src/pages/ProjectPage/ProjectPage.css
@@ -70,3 +70,18 @@
   width: 100%;
   filter: drop-shadow(0px 0px 10px rgba(0, 0, 0, 0.05));
 }
+
+@media (max-width: 768px) {
+  .project-container {
+    padding: 20px 16px;
+  }
+
+  .tabs-container {
+    overflow-x: auto;
+  }
+  
+  .tab-item {
+    padding: 10px 16px;
+    font-size: 13px;
+  }
+}

--- a/FE/src/pages/ProjectPage/ProjectPage.css
+++ b/FE/src/pages/ProjectPage/ProjectPage.css
@@ -1,0 +1,72 @@
+.project-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: calc(100vh - 56px);
+  background: linear-gradient(180deg, #F0F0F0 0%, #FFFFFF 100%);
+  overflow-y: auto;
+  padding: 19px 50px 20px 30px;
+  box-sizing: border-box;
+}
+
+.project-content {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 1000px;
+  gap: 20px;
+}
+
+.project-page-title {
+  font-family: 'YSpotlightOTF', 'Pretendard', sans-serif;
+  font-size: 22px;
+  font-weight: 500;
+  color: #000000;
+  flex-shrink: 0;
+}
+
+.tabs-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  height: 37px;
+}
+
+.tab-item {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 32px;
+  gap: 10px;
+  height: 37px;
+  box-sizing: border-box;
+  border-bottom: 1px solid #B3B3B3;
+  font-family: 'Pretendard', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  color: #000000;
+  line-height: 17px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.tab-item.active {
+  border-bottom: 1.5px solid #FF6600;
+  font-weight: 700;
+  color: #FF6600;
+}
+
+.tab-item:hover {
+  background-color: rgba(255, 102, 0, 0.05);
+}
+
+.project-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  filter: drop-shadow(0px 0px 10px rgba(0, 0, 0, 0.05));
+}

--- a/FE/src/pages/ProjectPage/ProjectPage.jsx
+++ b/FE/src/pages/ProjectPage/ProjectPage.jsx
@@ -5,9 +5,9 @@ import './ProjectPage.css';
 import { getDiffDays } from '../DashboardPage/components/DateUtils';
 
 const mockProjects = [
-  { id: 1, title: 'WAP 프로젝트', dueDate: '2026.06.05', currentStep: 125, totalStep: 150, bookmarked: true, applied: true },
-  { id: 2, title: '프로그래밍 팀플', dueDate: '2026.06.17', currentStep: 12, totalStep: 18, bookmarked: true, applied: true },
-  { id: 3, title: '캡스톤 디자인', dueDate: '2026.07.07', currentStep: 71, totalStep: 100, bookmarked: false, applied: true },
+  { id: 1, title: '프로그래밍 팀플', dueDate: '2026.05.17', currentStep: 12, totalStep: 18, bookmarked: true, applied: true },
+  { id: 2, title: 'WAP 프로젝트', dueDate: '2026.06.05', currentStep: 125, totalStep: 150, bookmarked: true, applied: true },
+  { id: 3, title: '캡스톤 디자인', dueDate: '2026.07.07', currentStep: 51, totalStep: 100, bookmarked: false, applied: true },
   { id: 4, title: '알고리즘 스터디', dueDate: '2023.05.10', currentStep: 93, totalStep: 100, bookmarked: false, applied: true },
   { id: 5, title: '인공지능 개발', dueDate: '2026.12.05', currentStep: 0, totalStep: 0, bookmarked: true, applied: false }
 ];

--- a/FE/src/pages/ProjectPage/ProjectPage.jsx
+++ b/FE/src/pages/ProjectPage/ProjectPage.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import ProjectBox from './components/ProjectBox/ProjectBox';
+import './ProjectPage.css';
+
+function ProjectPage() {
+  const [activeTab, setActiveTab] = useState('전체');
+
+  const tabs = ['전체', '진행중인 프로젝트', '내 지원 현황', '북마크', '완료된 프로젝트'];
+
+  // 임시 데이터
+  const dummyProjects = [
+    { id: 1, title: '캡스톤 디자인', dueDate: '2026.03.17', status: '여유', currentStep: 12, totalStep: 18, progress: 75 },
+    { id: 2, title: '캡스톤 디자인', dueDate: '2026.03.17', status: '여유', currentStep: 12, totalStep: 18, progress: 75 },
+    { id: 3, title: '캡스톤 디자인', dueDate: '2026.03.17', status: '여유', currentStep: 12, totalStep: 18, progress: 75 }
+  ];
+
+  return (
+    <div className="project-container">
+      <div className="project-content">
+        <h1 className="project-page-title">프로젝트</h1>
+        
+        <div className="tabs-container">
+          {tabs.map((tab) => (
+            <div 
+              key={tab} 
+              className={`tab-item ${activeTab === tab ? 'active' : ''}`}
+              onClick={() => setActiveTab(tab)}
+            >
+              {tab}
+            </div>
+          ))}
+        </div>
+
+        <div className="project-list">
+          {dummyProjects.map((project) => (
+            <ProjectBox 
+              key={project.id}
+              title={project.title}
+              dueDate={project.dueDate}
+              status={project.status}
+              currentStep={project.currentStep}
+              totalStep={project.totalStep}
+              progress={project.progress}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ProjectPage;

--- a/FE/src/pages/ProjectPage/ProjectPage.jsx
+++ b/FE/src/pages/ProjectPage/ProjectPage.jsx
@@ -9,9 +9,9 @@ function ProjectPage() {
 
   // 임시 데이터
   const dummyProjects = [
-    { id: 1, title: '캡스톤 디자인', dueDate: '2026.03.17', status: '여유', currentStep: 12, totalStep: 18, progress: 75 },
-    { id: 2, title: '캡스톤 디자인', dueDate: '2026.03.17', status: '여유', currentStep: 12, totalStep: 18, progress: 75 },
-    { id: 3, title: '캡스톤 디자인', dueDate: '2026.03.17', status: '여유', currentStep: 12, totalStep: 18, progress: 75 }
+    { id: 1, title: 'WAP 프로젝트', dueDate: '2026.06.05', status: '여유', currentStep: 125, totalStep: 150 },
+    { id: 2, title: '프로그래밍 팀플', dueDate: '2026.06.17', status: '여유', currentStep: 12, totalStep: 18 },
+    { id: 3, title: '캡스톤 디자인', dueDate: '2026.06.24', status: '여유', currentStep: 71, totalStep: 100 }
   ];
 
   return (
@@ -40,7 +40,6 @@ function ProjectPage() {
               status={project.status}
               currentStep={project.currentStep}
               totalStep={project.totalStep}
-              progress={project.progress}
             />
           ))}
         </div>

--- a/FE/src/pages/ProjectPage/ProjectPage.jsx
+++ b/FE/src/pages/ProjectPage/ProjectPage.jsx
@@ -1,20 +1,46 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ProjectBox from './components/ProjectBox/ProjectBox';
 import './ProjectPage.css';
+import { getDiffDays } from '../DashboardPage/components/DateUtils';
+
+const mockProjects = [
+  { id: 1, title: 'WAP 프로젝트', dueDate: '2026.06.05', currentStep: 125, totalStep: 150, bookmarked: true, applied: true },
+  { id: 2, title: '프로그래밍 팀플', dueDate: '2026.06.17', currentStep: 12, totalStep: 18, bookmarked: true, applied: true },
+  { id: 3, title: '캡스톤 디자인', dueDate: '2026.07.07', currentStep: 71, totalStep: 100, bookmarked: false, applied: true },
+  { id: 4, title: '알고리즘 스터디', dueDate: '2023.05.10', currentStep: 93, totalStep: 100, bookmarked: false, applied: true },
+  { id: 5, title: '인공지능 개발', dueDate: '2026.12.05', currentStep: 0, totalStep: 0, bookmarked: true, applied: false }
+];
+
+const tabs = [
+  { key: 'active', label: '진행중인 프로젝트' },
+  { key: 'applied', label: '내 지원 현황' },
+  { key: 'bookmarked', label: '북마크' },
+  { key: 'completed', label: '완료된 프로젝트' }
+];
 
 function ProjectPage() {
-  const [activeTab, setActiveTab] = useState('진행중인 프로젝트');
+  const [activeTab, setActiveTab] = useState('active');
   const navigate = useNavigate();
 
-  const tabs = ['진행중인 프로젝트', '내 지원 현황', '북마크', '완료된 프로젝트'];
+  const filteredProjects = useMemo(() => {
+    return mockProjects.filter((project) => {
+      const diffDays = getDiffDays(project.dueDate);
 
-  // 임시 데이터
-  const dummyProjects = [
-    { id: 1, title: 'WAP 프로젝트', dueDate: '2026.06.05', currentStep: 125, totalStep: 150 },
-    { id: 2, title: '프로그래밍 팀플', dueDate: '2026.06.17', currentStep: 12, totalStep: 18 },
-    { id: 3, title: '캡스톤 디자인', dueDate: '2026.06.24', currentStep: 71, totalStep: 100 }
-  ];
+      switch (activeTab) {
+        case 'active':
+          return project.applied && diffDays >= 0;
+        case 'applied':
+          return project.applied;
+        case 'bookmarked':
+          return project.bookmarked;
+        case 'completed':
+          return project.applied && diffDays < 0;
+        default:
+          return true;
+      }
+    });
+  }, [activeTab]);
 
   return (
     <div className="project-container">
@@ -24,26 +50,30 @@ function ProjectPage() {
         <div className="tabs-container">
           {tabs.map((tab) => (
             <div 
-              key={tab} 
-              className={`tab-item ${activeTab === tab ? 'active' : ''}`}
-              onClick={() => setActiveTab(tab)}
+              key={tab.key} 
+              className={`tab-item ${activeTab === tab.key ? 'active' : ''}`}
+              onClick={() => setActiveTab(tab.key)}
             >
-              {tab}
+              {tab.label}
             </div>
           ))}
         </div>
 
         <div className="project-list">
-          {dummyProjects.map((project) => (
-            <ProjectBox 
-              key={project.id}
-              title={project.title}
-              dueDate={project.dueDate}
-              currentStep={project.currentStep}
-              totalStep={project.totalStep}
-              onClick={() => navigate(`/project/${project.id}`)}
-            />
-          ))}
+          {filteredProjects.length > 0 ? (
+            filteredProjects.map((project) => (
+              <ProjectBox 
+                key={project.id}
+                title={project.title}
+                dueDate={project.dueDate}
+                currentStep={project.currentStep}
+                totalStep={project.totalStep}
+                onClick={() => navigate(`/project/${project.id}`)}
+              />
+            ))
+          ) : (
+            <div className="project-empty">해당하는 프로젝트가 없습니다.</div>
+          )}
         </div>
       </div>
     </div>

--- a/FE/src/pages/ProjectPage/ProjectPage.jsx
+++ b/FE/src/pages/ProjectPage/ProjectPage.jsx
@@ -2,14 +2,13 @@ import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ProjectBox from './components/ProjectBox/ProjectBox';
 import './ProjectPage.css';
-import { getDiffDays } from '../DashboardPage/components/DateUtils';
 
 const mockProjects = [
-  { id: 1, title: '프로그래밍 팀플', dueDate: '2026.05.17', currentStep: 12, totalStep: 18, bookmarked: true, applied: true },
-  { id: 2, title: 'WAP 프로젝트', dueDate: '2026.06.05', currentStep: 125, totalStep: 150, bookmarked: true, applied: true },
-  { id: 3, title: '캡스톤 디자인', dueDate: '2026.07.07', currentStep: 51, totalStep: 100, bookmarked: false, applied: true },
-  { id: 4, title: '알고리즘 스터디', dueDate: '2023.05.10', currentStep: 93, totalStep: 100, bookmarked: false, applied: true },
-  { id: 5, title: '인공지능 개발', dueDate: '2026.12.05', currentStep: 0, totalStep: 0, bookmarked: true, applied: false }
+  { id: 1, title: '프로그래밍 팀플', dueDate: '2026.05.17', currentStep: 12, totalStep: 18, bookmarked: true, applied: true, status: 'active' },
+  { id: 2, title: 'WAP 프로젝트', dueDate: '2026.06.05', currentStep: 125, totalStep: 150, bookmarked: true, applied: true, status: 'active' },
+  { id: 3, title: '캡스톤 디자인', dueDate: '2026.07.07', currentStep: 51, totalStep: 100, bookmarked: false, applied: true, status: 'active' },
+  { id: 4, title: '알고리즘 스터디', dueDate: '2023.05.10', currentStep: 93, totalStep: 100, bookmarked: false, applied: true, status: 'completed' },
+  { id: 5, title: '인공지능 개발', dueDate: '2026.12.05', currentStep: 0, totalStep: 0, bookmarked: true, applied: false, status: 'active' }
 ];
 
 const tabs = [
@@ -25,17 +24,15 @@ function ProjectPage() {
 
   const filteredProjects = useMemo(() => {
     return mockProjects.filter((project) => {
-      const diffDays = getDiffDays(project.dueDate);
-
       switch (activeTab) {
         case 'active':
-          return project.applied && diffDays >= 0;
+          return project.applied && project.status === 'active';
         case 'applied':
           return project.applied;
         case 'bookmarked':
           return project.bookmarked;
         case 'completed':
-          return project.applied && diffDays < 0;
+          return project.applied && project.status === 'completed';
         default:
           return true;
       }

--- a/FE/src/pages/ProjectPage/ProjectPage.jsx
+++ b/FE/src/pages/ProjectPage/ProjectPage.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import ProjectBox from './components/ProjectBox/ProjectBox';
 import './ProjectPage.css';
 
 function ProjectPage() {
   const [activeTab, setActiveTab] = useState('전체');
+  const navigate = useNavigate();
 
   const tabs = ['전체', '진행중인 프로젝트', '내 지원 현황', '북마크', '완료된 프로젝트'];
 
@@ -39,6 +41,7 @@ function ProjectPage() {
               dueDate={project.dueDate}
               currentStep={project.currentStep}
               totalStep={project.totalStep}
+              onClick={() => navigate(`/project/${project.id}`)}
             />
           ))}
         </div>

--- a/FE/src/pages/ProjectPage/ProjectPage.jsx
+++ b/FE/src/pages/ProjectPage/ProjectPage.jsx
@@ -13,14 +13,14 @@ const mockProjects = [
 ];
 
 const tabs = [
-  { key: 'active', label: '진행중인 프로젝트' },
-  { key: 'applied', label: '내 지원 현황' },
   { key: 'bookmarked', label: '북마크' },
+  { key: 'applied', label: '내 지원 현황' },
+  { key: 'active', label: '진행중인 프로젝트' },
   { key: 'completed', label: '완료된 프로젝트' }
 ];
 
 function ProjectPage() {
-  const [activeTab, setActiveTab] = useState('active');
+  const [activeTab, setActiveTab] = useState('bookmarked');
   const navigate = useNavigate();
 
   const filteredProjects = useMemo(() => {

--- a/FE/src/pages/ProjectPage/ProjectPage.jsx
+++ b/FE/src/pages/ProjectPage/ProjectPage.jsx
@@ -9,9 +9,9 @@ function ProjectPage() {
 
   // 임시 데이터
   const dummyProjects = [
-    { id: 1, title: 'WAP 프로젝트', dueDate: '2026.06.05', status: '여유', currentStep: 125, totalStep: 150 },
-    { id: 2, title: '프로그래밍 팀플', dueDate: '2026.06.17', status: '여유', currentStep: 12, totalStep: 18 },
-    { id: 3, title: '캡스톤 디자인', dueDate: '2026.06.24', status: '여유', currentStep: 71, totalStep: 100 }
+    { id: 1, title: 'WAP 프로젝트', dueDate: '2026.06.05', currentStep: 125, totalStep: 150 },
+    { id: 2, title: '프로그래밍 팀플', dueDate: '2026.06.17', currentStep: 12, totalStep: 18 },
+    { id: 3, title: '캡스톤 디자인', dueDate: '2026.06.24', currentStep: 71, totalStep: 100 }
   ];
 
   return (
@@ -37,7 +37,6 @@ function ProjectPage() {
               key={project.id}
               title={project.title}
               dueDate={project.dueDate}
-              status={project.status}
               currentStep={project.currentStep}
               totalStep={project.totalStep}
             />

--- a/FE/src/pages/ProjectPage/ProjectPage.jsx
+++ b/FE/src/pages/ProjectPage/ProjectPage.jsx
@@ -4,10 +4,10 @@ import ProjectBox from './components/ProjectBox/ProjectBox';
 import './ProjectPage.css';
 
 function ProjectPage() {
-  const [activeTab, setActiveTab] = useState('전체');
+  const [activeTab, setActiveTab] = useState('진행중인 프로젝트');
   const navigate = useNavigate();
 
-  const tabs = ['전체', '진행중인 프로젝트', '내 지원 현황', '북마크', '완료된 프로젝트'];
+  const tabs = ['진행중인 프로젝트', '내 지원 현황', '북마크', '완료된 프로젝트'];
 
   // 임시 데이터
   const dummyProjects = [

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
@@ -10,6 +10,11 @@
   background: #FFFFFF;
   border-radius: 10px;
   box-sizing: border-box;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.project-box:hover {
+  background-color: #f8f9fa;
 }
 
 .project-box-upper {

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
@@ -46,6 +46,8 @@
   flex-direction: row;
   align-items: center;
   gap: 16px;
+  flex: 1;
+  min-width: 0;
 }
 
 .project-box-text {
@@ -53,6 +55,8 @@
   flex-direction: column;
   gap: 6px;
   margin-top: 6px;
+  flex: 1;
+  min-width: 0;
 }
 
 .project-box-title {
@@ -62,6 +66,9 @@
   line-height: 19px;
   color: #000000;
   margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .project-due-date {
@@ -79,6 +86,7 @@
   justify-content: center;
   align-items: center;
   align-self: flex-start;
+  flex-shrink: 0;
 }
 
 .status-tag {
@@ -131,6 +139,10 @@
   color: #909090;
 }
 
+.mobile-only {
+  display: none;
+}
+
 .progress-stats {
   display: flex;
   flex-direction: row;
@@ -165,4 +177,67 @@
   position: absolute;
   left: -1px;
   top: -1px;
+}
+
+@media (max-width: 768px) {
+  .project-box {
+    padding: 12px 14px;
+    gap: 5px;
+  }
+
+  .project-box-upper {
+    gap: 3px;
+    flex-wrap: wrap;
+  }
+
+  .project-box-text {
+    margin-left: 8px;
+  }
+
+  .project-box-info {
+    gap: 8px;
+  }
+
+  .project-box-content {
+    display: contents;
+  }
+
+  .project-box-top {
+    flex: 1;
+    min-width: 0;
+    gap: 8px;
+  }
+
+  .progress-stats {
+    width: 100%;
+  }
+
+  .project-box-title {
+    font-size: 16px;
+  }
+
+  .project-due-date {
+    font-size: 12px;
+  }
+
+  .status-tag {
+    width: auto;
+    height: auto;
+    padding: 4px 12px;
+    font-size: 12px;
+    white-space: nowrap;
+  }
+
+  .progress-percent {
+    font-size: 22px;
+  }
+
+  .mobile-only {
+    display: block;
+    margin-right: auto;
+  }
+
+  .pc-only {
+    display: none;
+  }
 }

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
@@ -5,7 +5,8 @@
   gap: 3px;
   padding: 14px 20px;
   width: 100%;
-  height: 113px;
+  min-height: 113px;
+  height: auto;
   background: #FFFFFF;
   border-radius: 10px;
   box-sizing: border-box;
@@ -31,7 +32,8 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  height: 42px;
+  min-height: 42px;
+  height: auto;
 }
 
 .project-box-info {

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
@@ -110,6 +110,10 @@
   background: #FF7B7B;
 }
 
+.status-tag.closed {
+  background: #D9D9D9;
+}
+
 .project-box-bottom {
   display: flex;
   flex-direction: column;

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
@@ -1,13 +1,28 @@
 .project-box {
   display: flex;
   flex-direction: column;
+  justify-content: center;
+  gap: 3px;
   padding: 14px 20px;
-  gap: 10px;
   width: 100%;
-  height: 112px;
+  height: 113px;
   background: #FFFFFF;
   border-radius: 10px;
   box-sizing: border-box;
+}
+
+.project-box-upper {
+  display: flex;
+  width: 100%;
+  align-items: flex-start;
+  gap: 16px;
+  margin-top: 1px;
+}
+
+.project-box-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 
 .project-box-top {
@@ -16,7 +31,7 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  height: 54px;
+  height: 42px;
 }
 
 .project-box-info {
@@ -30,13 +45,13 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+  margin-top: 6px;
 }
 
-.project-title {
+.project-box-title {
   font-family: 'Pretendard', sans-serif;
   font-style: normal;
   font-weight: 600;
-  font-size: 16px;
   line-height: 19px;
   color: #000000;
   margin: 0;
@@ -56,15 +71,16 @@
   flex-direction: row;
   justify-content: center;
   align-items: center;
+  align-self: flex-start;
 }
 
 .status-badge {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 6px 26px;
+  width: 70px;
   height: 30px;
-  background: #D9D9D9;
+  background: #80D366;
   border-radius: 20px;
   font-family: 'Pretendard', sans-serif;
   font-style: normal;
@@ -85,9 +101,13 @@
 .progress-header {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
-  align-items: baseline;
-  margin-bottom: 4px;
+  align-items: center;
+  width: 100%;
+  gap: 12px;
+}
+
+.progress-header .progress-bar {
+  flex: 1;
 }
 
 .progress-label,
@@ -105,6 +125,7 @@
   flex-direction: row;
   align-items: baseline;
   gap: 8px;
+  justify-content: flex-end;
 }
 
 .progress-percent {
@@ -116,7 +137,7 @@
   line-height: 26px;
 }
 
-.progress-bar-container {
+.progress-bar {
   width: 100%;
   height: 8px;
   background: #F1F1F1;
@@ -126,7 +147,7 @@
   position: relative;
 }
 
-.progress-bar-fill {
+.progress-fill {
   height: 8px;
   background: #FE9A57;
   border-radius: 90px;

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
@@ -1,0 +1,136 @@
+.project-box {
+  display: flex;
+  flex-direction: column;
+  padding: 14px 20px;
+  gap: 10px;
+  width: 100%;
+  height: 112px;
+  background: #FFFFFF;
+  border-radius: 10px;
+  box-sizing: border-box;
+}
+
+.project-box-top {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 54px;
+}
+
+.project-box-info {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 16px;
+}
+
+.project-box-text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.project-title {
+  font-family: 'Pretendard', sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 19px;
+  color: #000000;
+  margin: 0;
+}
+
+.project-due-date {
+  font-family: 'Pretendard', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 17px;
+  color: #909090;
+}
+
+.project-box-status {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
+.status-badge {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 6px 26px;
+  height: 30px;
+  background: #D9D9D9;
+  border-radius: 20px;
+  font-family: 'Pretendard', sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 19px;
+  color: #FFFFFF;
+  box-sizing: border-box;
+}
+
+.project-box-bottom {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 40px;
+}
+
+.progress-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
+}
+
+.progress-label,
+.progress-step {
+  font-family: 'Pretendard', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 14px;
+  color: #909090;
+}
+
+.progress-stats {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.progress-percent {
+  font-family: 'YSpotlightOTF', 'Pretendard', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 20px;
+  color: #FF6600;
+  line-height: 26px;
+}
+
+.progress-bar-container {
+  width: 100%;
+  height: 8px;
+  background: #F1F1F1;
+  border: 1px solid #D9D9D9;
+  border-radius: 90px;
+  box-sizing: border-box;
+  position: relative;
+}
+
+.progress-bar-fill {
+  height: 8px;
+  background: #FE9A57;
+  border-radius: 90px;
+  position: absolute;
+  left: -1px;
+  top: -1px;
+}

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.css
@@ -74,7 +74,7 @@
   align-self: flex-start;
 }
 
-.status-badge {
+.status-tag {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -89,6 +89,10 @@
   line-height: 19px;
   color: #FFFFFF;
   box-sizing: border-box;
+}
+
+.status-tag.urgent {
+  background: #FF7B7B;
 }
 
 .project-box-bottom {

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.jsx
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import ProjectAvatar from '../../../../components/ProjectAvatar/ProjectAvatar';
+import ProgressBar from '../../../../components/ProgressBar/ProgressBar';
+import './ProjectBox.css';
+
+function ProjectBox({ title, dueDate, status, currentStep, totalStep, progress, avatarSrc }) {
+  return (
+    <div className="project-box">
+      <div className="project-box-top">
+        <div className="project-box-info">
+          <ProjectAvatar src={avatarSrc} size="54px" />
+          <div className="project-box-text">
+            <h3 className="project-box-title">{title}</h3>
+            <span className="project-due-date">마감일: {dueDate}</span>
+          </div>
+        </div>
+        <div className="project-box-status">
+          <span className="status-badge">{status}</span>
+        </div>
+      </div>
+      
+      <div className="project-box-bottom">
+        <div className="progress-header">
+          <span className="progress-label">진행률</span>
+          <span className="progress-stats">
+            <span className="progress-step">{currentStep}/{totalStep}</span>
+            <span className="progress-percent">{progress}%</span>
+          </span>
+        </div>
+        <ProgressBar percent={progress} />
+      </div>
+    </div>
+  );
+}
+
+export default ProjectBox;

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.jsx
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.jsx
@@ -31,6 +31,7 @@ function ProjectBox({ title, dueDate, currentStep, totalStep, avatarSrc, onClick
             </div>
           </div>
           <div className="progress-stats">
+            <span className="progress-label mobile-only">진행률</span>
             <span className="progress-step">{currentStep}/{totalStep}</span>
             <span className="progress-percent">{calculatedProgress}%</span>
           </div>
@@ -38,7 +39,7 @@ function ProjectBox({ title, dueDate, currentStep, totalStep, avatarSrc, onClick
       </div>
       
       <div className="progress-header">
-        <span className="progress-label">진행률</span>
+        <span className="progress-label pc-only">진행률</span>
         <ProgressBar percent={calculatedProgress} />
       </div>
     </div>

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.jsx
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.jsx
@@ -3,31 +3,35 @@ import ProjectAvatar from '../../../../components/ProjectAvatar/ProjectAvatar';
 import ProgressBar from '../../../../components/ProgressBar/ProgressBar';
 import './ProjectBox.css';
 
-function ProjectBox({ title, dueDate, status, currentStep, totalStep, progress, avatarSrc }) {
+function ProjectBox({ title, dueDate, status, currentStep, totalStep, avatarSrc }) {
+  const calculatedProgress = totalStep > 0 ? Math.round((currentStep / totalStep) * 100) : 0;
+
   return (
     <div className="project-box">
-      <div className="project-box-top">
-        <div className="project-box-info">
-          <ProjectAvatar src={avatarSrc} size="54px" />
-          <div className="project-box-text">
-            <h3 className="project-box-title">{title}</h3>
-            <span className="project-due-date">마감일: {dueDate}</span>
+      <div className="project-box-upper">
+        <ProjectAvatar src={avatarSrc} size="54px" />
+        <div className="project-box-content">
+          <div className="project-box-top">
+            <div className="project-box-info">
+              <div className="project-box-text">
+                <h4 className="project-box-title">{title}</h4>
+                <span className="project-due-date">마감일: {dueDate}</span>
+              </div>
+            </div>
+            <div className="project-box-status">
+              <span className="status-badge">{status}</span>
+            </div>
           </div>
-        </div>
-        <div className="project-box-status">
-          <span className="status-badge">{status}</span>
+          <div className="progress-stats">
+            <span className="progress-step">{currentStep}/{totalStep}</span>
+            <span className="progress-percent">{calculatedProgress}%</span>
+          </div>
         </div>
       </div>
       
-      <div className="project-box-bottom">
-        <div className="progress-header">
-          <span className="progress-label">진행률</span>
-          <span className="progress-stats">
-            <span className="progress-step">{currentStep}/{totalStep}</span>
-            <span className="progress-percent">{progress}%</span>
-          </span>
-        </div>
-        <ProgressBar percent={progress} />
+      <div className="progress-header">
+        <span className="progress-label">진행률</span>
+        <ProgressBar percent={calculatedProgress} />
       </div>
     </div>
   );

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.jsx
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.jsx
@@ -25,8 +25,8 @@ function ProjectBox({ title, dueDate, currentStep, totalStep, avatarSrc, onClick
               </div>
             </div>
             <div className="project-box-status">
-              <div className={`status-tag ${diffDays < 7 ? 'urgent' : ''}`}>
-                {diffDays < 7 ? '긴급' : '여유'}
+              <div className={`status-tag ${diffDays < 0 ? 'closed' : diffDays < 7 ? 'urgent' : ''}`}>
+                {diffDays < 0 ? '완료' : diffDays < 7 ? '긴급' : '여유'}
               </div>
             </div>
           </div>

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.jsx
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.jsx
@@ -4,12 +4,16 @@ import ProgressBar from '../../../../components/ProgressBar/ProgressBar';
 import { getDiffDays } from '../../../DashboardPage/components/DateUtils';
 import './ProjectBox.css';
 
-function ProjectBox({ title, dueDate, currentStep, totalStep, avatarSrc }) {
+function ProjectBox({ title, dueDate, currentStep, totalStep, avatarSrc, onClick }) {
   const calculatedProgress = totalStep > 0 ? Math.round((currentStep / totalStep) * 100) : 0;
   const diffDays = getDiffDays(dueDate);
 
   return (
-    <div className="project-box">
+    <div 
+      className="project-box" 
+      onClick={onClick} 
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+    >
       <div className="project-box-upper">
         <ProjectAvatar src={avatarSrc} size="54px" />
         <div className="project-box-content">

--- a/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.jsx
+++ b/FE/src/pages/ProjectPage/components/ProjectBox/ProjectBox.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import ProjectAvatar from '../../../../components/ProjectAvatar/ProjectAvatar';
 import ProgressBar from '../../../../components/ProgressBar/ProgressBar';
+import { getDiffDays } from '../../../DashboardPage/components/DateUtils';
 import './ProjectBox.css';
 
-function ProjectBox({ title, dueDate, status, currentStep, totalStep, avatarSrc }) {
+function ProjectBox({ title, dueDate, currentStep, totalStep, avatarSrc }) {
   const calculatedProgress = totalStep > 0 ? Math.round((currentStep / totalStep) * 100) : 0;
+  const diffDays = getDiffDays(dueDate);
 
   return (
     <div className="project-box">
@@ -19,7 +21,9 @@ function ProjectBox({ title, dueDate, status, currentStep, totalStep, avatarSrc 
               </div>
             </div>
             <div className="project-box-status">
-              <span className="status-badge">{status}</span>
+              <div className={`status-tag ${diffDays < 7 ? 'urgent' : ''}`}>
+                {diffDays < 7 ? '긴급' : '여유'}
+              </div>
             </div>
           </div>
           <div className="progress-stats">


### PR DESCRIPTION
## 📌 개요
프로젝트 상태별로 목록을 확인할 수 있는 프로젝트 페이지 UI를 구현했습니다.

## ⚙️ 작업 내용
- 프로젝트 페이지 상단 탭 UI 구현
- 프로젝트 정보 표시하는 프로젝트 박스 컴포넌트 UI 구현
- 프로젝트 진행률 로직 및 상태 배지 로직 구현
- 전체 페이지 레이아웃 및 반응형 구현

### pc 버전
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/392e1d35-0807-43a0-acac-b8567af2d91b" />

### 모바일 버전(아이폰 xr)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/5ca1574b-5606-4632-aab0-1739574af305" />

 
## 🎸 기타사항
탭 별 프로젝트 세부 구현 디자인은 진행중입니다.
