### PR TITLE
[fix] 로그인 인증 흐름 수정

### DIFF
--- a/FE/src/api/kakaoAuthApi.js
+++ b/FE/src/api/kakaoAuthApi.js
@@ -42,3 +42,30 @@ export async function requestKakaoLogin(code, state) {
 
   return result.data;
 }
+
+export async function reissueKakaoToken(refreshToken, accessToken) {
+  const response = await fetch(`${baseUrl}/api/auth/kakao/reissue`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  if (!response.ok) {
+    let message = `토큰 재발급에 실패했습니다. (Status: ${response.status})`;
+    try {
+      const errorResult = await response.json();
+      message = errorResult.message || message;
+    } catch (e) {}
+    throw new Error(message);
+  }
+
+  const result = await response.json();
+  if (!result.isSuccess) {
+    throw new Error(result.message || "토큰 재발급에 실패했습니다.");
+  }
+
+  return result.data;
+}

--- a/FE/src/pages/AuthCallback/AuthCallback.jsx
+++ b/FE/src/pages/AuthCallback/AuthCallback.jsx
@@ -28,12 +28,7 @@ export default function AuthCallback() {
       try {
         const data = await requestKakaoLogin(code, state);
         if (data) {
-          login(data.accessToken);
-
-          if (data.profileCompleted === false) {
-            navigate("/profile-setup");
-            return;
-          }
+          login(data.accessToken, data.refreshToken);
         }
         navigate("/dashboard");
       } catch (err) {

--- a/FE/src/pages/LoginPage/components/LoginForm.jsx
+++ b/FE/src/pages/LoginPage/components/LoginForm.jsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import kakaoLogo from "../../../assets/kakao_logo.svg";
 
-const baseUrl = import.meta.env.VITE_API_BASE_URL;
-
 function LoginForm({ onLogin, isLoading }) {
   const [keepLogin, setKeepLogin] = useState(false);
 
@@ -13,18 +11,19 @@ function LoginForm({ onLogin, isLoading }) {
 
   return (
     <form className="login-form" onSubmit={handleSubmit}>
-      <a
-        href={`${baseUrl}/api/auth/kakao/login`}
+      <button
+        type="submit"
         className="kakao-login-btn"
+        disabled={isLoading}
       >
         <span className="kakao-login-content">
           <img src={kakaoLogo} alt="카카오 로고" className="kakao-icon" />
 
           <span className="kakao-login-text">
-            카카오 로그인으로 시작
+            {isLoading ? "이동 중..." : "카카오 로그인으로 시작"}
           </span>
         </span>
-      </a>
+      </button>
     </form>
   );
 }

--- a/FE/src/stores/useAuthStore.js
+++ b/FE/src/stores/useAuthStore.js
@@ -2,12 +2,14 @@ import { create } from "zustand";
 
 export const useAuthStore = create((set) => ({
   isLoggedIn: !!localStorage.getItem("accessToken"),
-  login: (accessToken) => {
+  login: (accessToken, refreshToken) => {
     if (accessToken) localStorage.setItem("accessToken", accessToken);
+    if (refreshToken) localStorage.setItem("refreshToken", refreshToken);
     set({ isLoggedIn: true });
   },
   logout: () => {
     localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
     set({ isLoggedIn: false });
   },
 }));


### PR DESCRIPTION
## 📌 개요
백엔드의 로그인 응답 방식 및 토큰 처리 방식 변경에 맞춰 프론트 인증 흐름을 수정했습니다.

## ⚙️ 작업 내용
- 백엔드 카카오 로그인 API 수정사항에 맞춰 로그인 버튼 동작 방식 변경
- 로그인 버튼 클릭 시 백엔드에 카카오 로그인 URL 요청 후 리다이렉트 처리
- 카카오 콜백 페이지에서 백엔드 콜백 API 호출 후 토큰 저장
- 로그인 성공 시 accessToken, refreshToken을 Zustand Store에 저장하도록 수정
- 로그인 완료 후 대시보드 페이지로 이동하도록 처리
- 토큰 재발급(Reissue) API 함수 추가
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
