### PR TITLE
[feat] 공통 - 헤더 프로필 페이지 이동 구현

### DIFF
--- a/FE/src/components/Header/Header.css
+++ b/FE/src/components/Header/Header.css
@@ -83,6 +83,10 @@
   gap: 12px;
 }
 
+.header-right a {
+  text-decoration: none;
+}
+
 .header-greeting {
   font-family: 'Pretendard', sans-serif;
   font-size: 14px;

--- a/FE/src/components/Header/Header.jsx
+++ b/FE/src/components/Header/Header.jsx
@@ -40,10 +40,12 @@ function Header({ onMenuClick }) {
       </div>
 
       <div className="header-right">
-        <span className="header-greeting">
+        <Link to="/profile" className="header-greeting">
           <strong>{userData.userName}</strong> 님 안녕하세요 :)
-        </span>
-        <div className="header-avatar">{userData.userInitial}</div>
+        </Link>
+        <Link to="/profile">
+          <div className="header-avatar">{userData.userInitial}</div>
+        </Link>
       </div>
     </header>
   );


### PR DESCRIPTION
## 📌 개요
헤더의 닉네임 영역, 아바타 클릭 시 프로필 페이지로 이동하는 로직 구현했습니다.

## ⚙️ 작업 내용
- 헤더의 닉네임 영역 클릭 시 프로필 페이지로 이동하도록 설정
- 헤더의 아바타 클릭 시 프로필 페이지로 이동하도록 설정
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
