### PR TITLE
[style] 공통 - 페이지 타이틀 위치 통일

### DIFF
--- a/FE/src/pages/FindTeam/FindTeamPage.css
+++ b/FE/src/pages/FindTeam/FindTeamPage.css
@@ -1,6 +1,6 @@
 .find-team-page {
   min-height: 100%;
-  padding: 24px 0 40px 26px;
+  padding: 19px 50px 20px 30px;
   background: linear-gradient(180deg, #F0F0F0 0%, #FFFFFF 100%);
   color: #111111;
   font-family: "Pretendard", "Noto Sans KR", sans-serif;
@@ -9,7 +9,7 @@
 .find-team-title {
   margin: 0 0 16px;
   font-family: "YSpotlightOTF", "Pretendard", sans-serif;
-  font-size: 21px;
+  font-size: 22px;
   line-height: 27px;
   font-weight: 500;
   letter-spacing: 0;

--- a/FE/src/pages/ProfilePage/ProfilePage.css
+++ b/FE/src/pages/ProfilePage/ProfilePage.css
@@ -3,8 +3,7 @@
 .page-wrapper {
   overflow-x: hidden;
   min-height: 100%;
-  padding: 32px 36px;
-  margin: 0;
+  padding: 19px 50px 20px 30px;
   background: linear-gradient(180deg, #F0F0F0 0%, #FFFFFF 100%);
   box-sizing: border-box;
   display: flex;
@@ -14,8 +13,8 @@
 
 .page-title {
   font-family: 'YSpotlightOTF', 'Pretendard Variable', 'Pretendard', sans-serif;
-  font-size: 24px;
-  font-weight: 400;
+  font-size: 22px;
+  font-weight: 500;
   color: #000;
   margin: 0 0 20px 0;
 }

--- a/FE/src/pages/Teammaking/TeammakingPage.css
+++ b/FE/src/pages/Teammaking/TeammakingPage.css
@@ -14,7 +14,7 @@ body {
   height: 100%;
   overflow: hidden;
   background-color: #f8f8f8;
-  padding: 21px 30px 0;
+  padding: 19px 50px 20px 30px;
   background: linear-gradient(180deg, #f0f0f0 0%, #ffffff 100%);
 }
 
@@ -23,10 +23,10 @@ body {
   max-width: 100%;
   margin: 0 0 18px;
   margin-left: 0;
-  font-size: 21px;
+  font-size: 22px;
   line-height: 27px;
   font-family: "YSpotlightOTF", "Pretendard", sans-serif;
-  font-weight: 800;
+  font-weight: 500;
   color: #1a1a1a;
 }
 


### PR DESCRIPTION
## 📌 개요
페이지마다 다르게 배치되어 있던 타이틀 텍스트 위치를 통일하여 화면 구조의 일관성을 개선했습니다.

## ⚙️ 작업 내용
- 페이지의 타이틀 텍스트 위치 조정
- 페이지의 타이틀 텍스트 크기 및 굵기 조정
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
