### PR TITLE
[feat] 사용자 프로필 및 프로젝트 활동 조회 기능 구현

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/project/repository/MemberRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/repository/MemberRepository.java
@@ -11,4 +11,5 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
 
     Optional<Member> findByIdAndProjectId(Long userId,Long projectId);
     Optional<Member> findByUserIdAndProjectId(Long userId,Long projectId);
+    Optional<Member> findByUserId(Long userId);
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/user/code/UserSuccessCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/code/UserSuccessCode.java
@@ -1,0 +1,25 @@
+package org.example.promate.domain.user.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.promate.global.ApiPayload.code.BaseSuccessCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserSuccessCode implements BaseSuccessCode {
+
+    GET_USER_SUCCESS(HttpStatus.OK, "USER_S001", "회원 정보 조회에 성공했습니다."),
+    UPDATE_USER_SUCCESS(HttpStatus.OK, "USER_S002", "프로필 수정에 성공했습니다."),
+
+    GET_PROJECT_HISTORY_SUCCESS(HttpStatus.OK, "USER_S003", "프로젝트 이력 조회에 성공했습니다."),
+    CREATE_PROJECT_HISTORY_SUCCESS(HttpStatus.OK, "USER_S004", "프로젝트 이력 등록에 성공했습니다."),
+    UPDATE_PROJECT_HISTORY_SUCCESS(HttpStatus.OK, "USER_S005", "프로젝트 이력 수정에 성공했습니다."),
+    DELETE_PROJECT_HISTORY_SUCCESS(HttpStatus.OK, "USER_S006", "프로젝트 이력 삭제에 성공했습니다."),
+
+    GET_PROJECT_TASK_COUNT_SUCCESS(HttpStatus.OK, "USER_S007", "프로젝트별 태스크 개수 조회에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/user/controller/UserController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package org.example.promate.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.user.code.UserSuccessCode;
 import org.example.promate.domain.user.dto.*;
 import org.example.promate.domain.user.service.UserService;
 import org.example.promate.global.ApiPayload.ApiResponse;
@@ -22,7 +23,7 @@ public class UserController {
             @AuthenticationPrincipal Long userId
     ) {
         return ApiResponse.onSuccess(
-                GeneralSuccessCode.OK,
+                UserSuccessCode.GET_USER_SUCCESS,
                 userService.getUser(userId)
         );
     }
@@ -33,7 +34,7 @@ public class UserController {
             @RequestBody UserProfileUpdateRequestDTO request
     ) {
         return ApiResponse.onSuccess(
-                GeneralSuccessCode.OK,
+                UserSuccessCode.UPDATE_USER_SUCCESS,
                 userService.updateUserProfile(userId, request)
         );
     }
@@ -43,7 +44,7 @@ public class UserController {
             @AuthenticationPrincipal Long userId
     ) {
         return ApiResponse.onSuccess(
-                GeneralSuccessCode.OK,
+                UserSuccessCode.GET_PROJECT_HISTORY_SUCCESS,
                 userService.getMyProjectHistories(userId)
         );
     }
@@ -54,7 +55,7 @@ public class UserController {
             @RequestBody UserProjectHistoryRequestDTO request
     ) {
         return ApiResponse.onSuccess(
-                GeneralSuccessCode.OK,
+                UserSuccessCode.CREATE_PROJECT_HISTORY_SUCCESS,
                 userService.createProjectHistory(userId, request)
         );
     }
@@ -66,7 +67,7 @@ public class UserController {
             @RequestBody UserProjectHistoryRequestDTO request
     ) {
         return ApiResponse.onSuccess(
-                GeneralSuccessCode.OK,
+                UserSuccessCode.UPDATE_PROJECT_HISTORY_SUCCESS,
                 userService.updateProjectHistory(userId, historyId, request)
         );
     }
@@ -79,7 +80,7 @@ public class UserController {
         userService.deleteProjectHistory(userId, historyId);
 
         return ApiResponse.onSuccess(
-                GeneralSuccessCode.OK,
+                UserSuccessCode.DELETE_PROJECT_HISTORY_SUCCESS,
                 null
         );
     }
@@ -89,7 +90,7 @@ public class UserController {
             @AuthenticationPrincipal Long userId
     ) {
         return ApiResponse.onSuccess(
-                GeneralSuccessCode.OK,
+                UserSuccessCode.GET_PROJECT_TASK_COUNT_SUCCESS,
                 userService.getProjectTaskCounts(userId)
         );
     }

--- a/BE/promate/src/main/java/org/example/promate/domain/user/controller/UserController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/controller/UserController.java
@@ -18,48 +18,70 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/me")
-    public UserResponseDTO getMyInfo(@AuthenticationPrincipal Long userId) {
-        return userService.getUser(userId);
+    public ApiResponse<UserResponseDTO> getMyInfo(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                userService.getUser(userId)
+        );
     }
 
     @PatchMapping("/me")
-    public UserResponseDTO updateMyInfo(
+    public ApiResponse<UserResponseDTO> updateMyInfo(
             @AuthenticationPrincipal Long userId,
             @RequestBody UserProfileUpdateRequestDTO request
     ) {
-        return userService.updateUserProfile(userId, request);
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                userService.updateUserProfile(userId, request)
+        );
     }
 
     @GetMapping("/me/projectHistories")
-    public List<UserProjectHistoryResponseDTO> getMyProjectHistories(
+    public ApiResponse<List<UserProjectHistoryResponseDTO>> getMyProjectHistories(
             @AuthenticationPrincipal Long userId
     ) {
-        return userService.getMyProjectHistories(userId);
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                userService.getMyProjectHistories(userId)
+        );
     }
 
     @PostMapping("/me/projectHistories")
-    public UserProjectHistoryResponseDTO createProjectHistory(
+    public ApiResponse<UserProjectHistoryResponseDTO> createProjectHistory(
             @AuthenticationPrincipal Long userId,
             @RequestBody UserProjectHistoryRequestDTO request
     ) {
-        return userService.createProjectHistory(userId, request);
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                userService.createProjectHistory(userId, request)
+        );
     }
 
     @PatchMapping("/me/projectHistories/{historyId}")
-    public UserProjectHistoryResponseDTO updateProjectHistory(
+    public ApiResponse<UserProjectHistoryResponseDTO> updateProjectHistory(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long historyId,
             @RequestBody UserProjectHistoryRequestDTO request
     ) {
-        return userService.updateProjectHistory(userId, historyId, request);
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                userService.updateProjectHistory(userId, historyId, request)
+        );
     }
 
     @DeleteMapping("/me/projectHistories/{historyId}")
-    public void deleteProjectHistory(
+    public ApiResponse<Void> deleteProjectHistory(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long historyId
     ) {
         userService.deleteProjectHistory(userId, historyId);
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                null
+        );
     }
 
     @GetMapping("/me/projects/task-counts")

--- a/BE/promate/src/main/java/org/example/promate/domain/user/controller/UserController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/controller/UserController.java
@@ -1,11 +1,10 @@
 package org.example.promate.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.example.promate.domain.user.dto.UserProfileUpdateRequestDTO;
-import org.example.promate.domain.user.dto.UserProjectHistoryRequestDTO;
-import org.example.promate.domain.user.dto.UserProjectHistoryResponseDTO;
-import org.example.promate.domain.user.dto.UserResponseDTO;
+import org.example.promate.domain.user.dto.*;
 import org.example.promate.domain.user.service.UserService;
+import org.example.promate.global.ApiPayload.ApiResponse;
+import org.example.promate.global.ApiPayload.code.GeneralSuccessCode;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -63,4 +62,13 @@ public class UserController {
         userService.deleteProjectHistory(userId, historyId);
     }
 
+    @GetMapping("/me/projects/task-counts")
+    public ApiResponse<List<ProjectTaskCountResponseDTO>> getProjectTaskCounts(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                userService.getProjectTaskCounts(userId)
+        );
+    }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/user/controller/UserController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/controller/UserController.java
@@ -2,10 +2,14 @@ package org.example.promate.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.promate.domain.user.dto.UserProfileUpdateRequestDTO;
+import org.example.promate.domain.user.dto.UserProjectHistoryRequestDTO;
+import org.example.promate.domain.user.dto.UserProjectHistoryResponseDTO;
 import org.example.promate.domain.user.dto.UserResponseDTO;
 import org.example.promate.domain.user.service.UserService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,6 +29,38 @@ public class UserController {
             @RequestBody UserProfileUpdateRequestDTO request
     ) {
         return userService.updateUserProfile(userId, request);
+    }
+
+    @GetMapping("/me/projectHistories")
+    public List<UserProjectHistoryResponseDTO> getMyProjectHistories(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return userService.getMyProjectHistories(userId);
+    }
+
+    @PostMapping("/me/projectHistories")
+    public UserProjectHistoryResponseDTO createProjectHistory(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody UserProjectHistoryRequestDTO request
+    ) {
+        return userService.createProjectHistory(userId, request);
+    }
+
+    @PatchMapping("/me/projectHistories/{historyId}")
+    public UserProjectHistoryResponseDTO updateProjectHistory(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long historyId,
+            @RequestBody UserProjectHistoryRequestDTO request
+    ) {
+        return userService.updateProjectHistory(userId, historyId, request);
+    }
+
+    @DeleteMapping("/me/projectHistories/{historyId}")
+    public void deleteProjectHistory(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long historyId
+    ) {
+        userService.deleteProjectHistory(userId, historyId);
     }
 
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/user/dto/ProjectTaskCountResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/dto/ProjectTaskCountResponseDTO.java
@@ -1,0 +1,13 @@
+package org.example.promate.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProjectTaskCountResponseDTO {
+    private Long projectId;
+    private String projectTitle;
+    private int completedTaskCount;
+    private int incompleteTaskCount;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/user/dto/PromateExperienceResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/dto/PromateExperienceResponseDTO.java
@@ -1,0 +1,18 @@
+package org.example.promate.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.promate.domain.project.enums.ProjectStatus;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class PromateExperienceResponseDTO {
+    private Long projectId;
+    private String projectTitle;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private ProjectStatus projectStatus;
+    private Double peerEvaluationScore;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/user/dto/UserProfileResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/dto/UserProfileResponseDTO.java
@@ -1,0 +1,35 @@
+package org.example.promate.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.promate.domain.user.entity.User;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserProfileResponseDTO {
+
+    private Long id;
+    private Long kakaoId;
+    private String name;
+    private String profileImageUrl;
+
+    private List<UserPromateProjectResponseDTO> promateProjects;
+    private List<UserProjectHistoryResponseDTO> customProjects;
+
+    public static UserProfileResponseDTO of(
+            User user,
+            List<UserPromateProjectResponseDTO> promateProjects,
+            List<UserProjectHistoryResponseDTO> customProjects
+    ) {
+        return UserProfileResponseDTO.builder()
+                .id(user.getId())
+                .kakaoId(user.getKakaoId())
+                .name(user.getName())
+                .profileImageUrl(user.getProfileImageUrl())
+                .promateProjects(promateProjects)
+                .customProjects(customProjects)
+                .build();
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/user/dto/UserProfileUpdateRequestDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/dto/UserProfileUpdateRequestDTO.java
@@ -9,5 +9,4 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserProfileUpdateRequestDTO {
     private String name;
-    private String profileImageUrl;
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/user/dto/UserProjectHistoryRequestDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/dto/UserProjectHistoryRequestDTO.java
@@ -1,0 +1,12 @@
+package org.example.promate.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserProjectHistoryRequestDTO {
+
+    private String projectName;
+    private String role;
+    private String period;
+    private String description;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/user/dto/UserProjectHistoryResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/dto/UserProjectHistoryResponseDTO.java
@@ -1,0 +1,28 @@
+package org.example.promate.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.promate.domain.user.entity.UserProjectHistory;
+
+@Getter
+@Builder
+public class UserProjectHistoryResponseDTO {
+
+    private Long historyId;
+    private String projectName;
+    private String role;
+    private String period;
+    private String description;
+    private Boolean editable;
+
+    public static UserProjectHistoryResponseDTO from(UserProjectHistory history) {
+        return UserProjectHistoryResponseDTO.builder()
+                .historyId(history.getId())
+                .projectName(history.getProjectName())
+                .role(history.getRole())
+                .period(history.getPeriod())
+                .description(history.getDescription())
+                .editable(true)
+                .build();
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/user/dto/UserPromateProjectResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/dto/UserPromateProjectResponseDTO.java
@@ -1,0 +1,15 @@
+package org.example.promate.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserPromateProjectResponseDTO {
+
+    private Long projectId;
+    private String projectName;
+    private String role;
+    private String period;
+    private Boolean editable;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/user/entity/User.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/entity/User.java
@@ -64,9 +64,8 @@ public class User extends BaseEntity {
     @Builder.Default
     private List<Apply> applies = new ArrayList<>();
 
-    public void updateProfile(String name, String profileImageUrl) {
+    public void updateProfile(String name) {
         this.name = name;
-        this.profileImageUrl = profileImageUrl;
         this.isProfileCompleted = true;
     }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/user/entity/User.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/entity/User.java
@@ -64,6 +64,10 @@ public class User extends BaseEntity {
     @Builder.Default
     private List<Apply> applies = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<UserProjectHistory> projectHistories = new ArrayList<>();
+
     public void updateProfile(String name) {
         this.name = name;
         this.isProfileCompleted = true;

--- a/BE/promate/src/main/java/org/example/promate/domain/user/entity/UserProjectHistory.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/entity/UserProjectHistory.java
@@ -1,0 +1,42 @@
+package org.example.promate.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.example.promate.global.entity.BaseEntity;
+
+@Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_project_history")
+public class UserProjectHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="project_name", nullable = false)
+    private String projectName;
+
+    @Column(name="role", nullable = true)
+    private String role;
+
+    @Column(name="period", nullable = true)
+    private String period;
+
+    @Column(name="description", columnDefinition = "TEXT", nullable = true)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public void update(String projectName, String role, String period, String description) {
+        this.projectName = projectName;
+        this.role = role;
+        this.period = period;
+        this.description = description;
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/user/exception/UserErrorCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/exception/UserErrorCode.java
@@ -1,21 +1,24 @@
 package org.example.promate.domain.user.exception;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.example.promate.global.ApiPayload.code.BaseErrorCode;
 import org.springframework.http.HttpStatus;
 
 @Getter
+@AllArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "해당 유저가 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_E001", "사용자를 찾을 수 없습니다."),
+
+    PROJECT_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_E002", "프로젝트 이력을 찾을 수 없습니다."),
+
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "USER_E003", "인증 토큰이 유효하지 않습니다."),
+
+    FORBIDDEN_PROJECT_HISTORY(HttpStatus.FORBIDDEN, "USER_E004", "해당 프로젝트 이력에 접근할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;
     private final String message;
 
-    UserErrorCode(HttpStatus status, String code, String message) {
-        this.status = status;
-        this.code = code;
-        this.message = message;
-    }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/user/exception/UserExceptionHandler.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/exception/UserExceptionHandler.java
@@ -1,0 +1,23 @@
+package org.example.promate.domain.user.exception;
+
+import org.example.promate.global.ApiPayload.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class UserExceptionHandler {
+
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUserException(UserException e) {
+
+        UserErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(
+                        errorCode,
+                        null
+                ));
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/user/repository/UserProjectHistoryRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/repository/UserProjectHistoryRepository.java
@@ -1,0 +1,13 @@
+package org.example.promate.domain.user.repository;
+
+import org.example.promate.domain.user.entity.UserProjectHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface UserProjectHistoryRepository extends JpaRepository<UserProjectHistory, Long> {
+
+    List<UserProjectHistory> findByUserId(Long userId);
+
+    Optional<UserProjectHistory> findByIdAndUserId(Long id, Long userId);
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/user/service/UserService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/service/UserService.java
@@ -81,7 +81,7 @@ public class UserService {
             UserProjectHistoryRequestDTO request
     ) {
         UserProjectHistory history = userProjectHistoryRepository.findByIdAndUserId(historyId, userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND)); // 커스텀에러 추후 추가 예정
+                .orElseThrow(() -> new UserException(UserErrorCode.PROJECT_HISTORY_NOT_FOUND)); // 커스텀에러 추후 추가 예정
 
         history.update(
                 request.getProjectName(),
@@ -96,7 +96,7 @@ public class UserService {
     @Transactional
     public void deleteProjectHistory(Long userId, Long historyId) {
         UserProjectHistory history = userProjectHistoryRepository.findByIdAndUserId(historyId, userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND)); // 커스텀에러 추후 추가 예정
+                .orElseThrow(() -> new UserException(UserErrorCode.PROJECT_HISTORY_NOT_FOUND)); // 커스텀에러 추후 추가 예정
 
         userProjectHistoryRepository.delete(history);
     }

--- a/BE/promate/src/main/java/org/example/promate/domain/user/service/UserService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/service/UserService.java
@@ -30,8 +30,7 @@ public class UserService {
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         user.updateProfile(
-                request.getName(),
-                request.getProfileImageUrl()
+                request.getName()
         );
 
         return UserResponseDTO.from(user);

--- a/BE/promate/src/main/java/org/example/promate/domain/user/service/UserService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/service/UserService.java
@@ -2,13 +2,19 @@ package org.example.promate.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.promate.domain.user.dto.UserProfileUpdateRequestDTO;
+import org.example.promate.domain.user.dto.UserProjectHistoryRequestDTO;
+import org.example.promate.domain.user.dto.UserProjectHistoryResponseDTO;
 import org.example.promate.domain.user.dto.UserResponseDTO;
 import org.example.promate.domain.user.entity.User;
+import org.example.promate.domain.user.entity.UserProjectHistory;
 import org.example.promate.domain.user.exception.UserErrorCode;
 import org.example.promate.domain.user.exception.UserException;
+import org.example.promate.domain.user.repository.UserProjectHistoryRepository;
 import org.example.promate.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +40,64 @@ public class UserService {
         );
 
         return UserResponseDTO.from(user);
+    }
+
+    private final UserProjectHistoryRepository userProjectHistoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<UserProjectHistoryResponseDTO> getMyProjectHistories(Long userId) {
+        return userProjectHistoryRepository.findByUserId(userId)
+                .stream()
+                .map(UserProjectHistoryResponseDTO::from)
+                .toList();
+    }
+
+    @Transactional
+    public UserProjectHistoryResponseDTO createProjectHistory(
+            Long userId,
+            UserProjectHistoryRequestDTO request
+    ) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND)); // 커스텀에러 추후 추가 예정
+
+        UserProjectHistory history = UserProjectHistory.builder()
+                .user(user)
+                .projectName(request.getProjectName())
+                .role(request.getRole())
+                .period(request.getPeriod())
+                .description(request.getDescription())
+                .build();
+
+        UserProjectHistory savedHistory = userProjectHistoryRepository.save(history);
+
+        return UserProjectHistoryResponseDTO.from(savedHistory);
+    }
+
+    @Transactional
+    public UserProjectHistoryResponseDTO updateProjectHistory(
+            Long userId,
+            Long historyId,
+            UserProjectHistoryRequestDTO request
+    ) {
+        UserProjectHistory history = userProjectHistoryRepository.findByIdAndUserId(historyId, userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND)); // 커스텀에러 추후 추가 예정
+
+        history.update(
+                request.getProjectName(),
+                request.getRole(),
+                request.getPeriod(),
+                request.getDescription()
+        );
+
+        return UserProjectHistoryResponseDTO.from(history);
+    }
+
+    @Transactional
+    public void deleteProjectHistory(Long userId, Long historyId) {
+        UserProjectHistory history = userProjectHistoryRepository.findByIdAndUserId(historyId, userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND)); // 커스텀에러 추후 추가 예정
+
+        userProjectHistoryRepository.delete(history);
     }
 
 

--- a/BE/promate/src/main/java/org/example/promate/domain/user/service/UserService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/service/UserService.java
@@ -1,16 +1,17 @@
 package org.example.promate.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
-import org.example.promate.domain.user.dto.UserProfileUpdateRequestDTO;
-import org.example.promate.domain.user.dto.UserProjectHistoryRequestDTO;
-import org.example.promate.domain.user.dto.UserProjectHistoryResponseDTO;
-import org.example.promate.domain.user.dto.UserResponseDTO;
+import org.example.promate.domain.project.entity.Project;
+import org.example.promate.domain.project.repository.MemberRepository;
+import org.example.promate.domain.user.dto.*;
 import org.example.promate.domain.user.entity.User;
 import org.example.promate.domain.user.entity.UserProjectHistory;
 import org.example.promate.domain.user.exception.UserErrorCode;
 import org.example.promate.domain.user.exception.UserException;
 import org.example.promate.domain.user.repository.UserProjectHistoryRepository;
 import org.example.promate.domain.user.repository.UserRepository;
+import org.example.promate.domain.workspace.enums.TaskStatus;
+import org.example.promate.domain.workspace.repository.TaskRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -98,6 +99,35 @@ public class UserService {
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND)); // 커스텀에러 추후 추가 예정
 
         userProjectHistoryRepository.delete(history);
+    }
+
+    private final MemberRepository memberRepository;
+    private final TaskRepository taskRepository;
+
+    public List<ProjectTaskCountResponseDTO> getProjectTaskCounts(Long userId) {
+        return memberRepository.findByUserId(userId)
+                .stream()
+                .map(member -> {
+                    Project project = member.getProject();
+
+                    int completedCount = taskRepository.countByProjectIdAndStatus(
+                            project.getId(),
+                            TaskStatus.DONE
+                    );
+
+                    int incompleteCount = taskRepository.countByProjectIdAndStatusIn(
+                            project.getId(),
+                            List.of(TaskStatus.TODO, TaskStatus.IN_PROGRESS)
+                    );
+
+                    return ProjectTaskCountResponseDTO.builder()
+                            .projectId(project.getId())
+                            .projectTitle(project.getTitle())
+                            .completedTaskCount(completedCount)
+                            .incompleteTaskCount(incompleteCount)
+                            .build();
+                })
+                .toList();
     }
 
 

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
@@ -23,4 +23,7 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             "where t.id = :taskId " +
             "and t.isDeleted = false")
     Optional<Task> findByIdAndIsDeletedFalse(@Param("taskId")Long id);
+    
+    int countByProjectIdAndStatus(Long projectId, TaskStatus status);
+    int countByProjectIdAndStatusIn(Long projectId, List<TaskStatus> statuses); // 완료, 미완료 task 조회
 }

--- a/BE/promate/src/main/java/org/example/promate/global/auth/dto/KakaoUserResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/global/auth/dto/KakaoUserResponseDTO.java
@@ -21,6 +21,8 @@ public class KakaoUserResponseDTO {
     @Getter
     public static class Profile {
 
+        private String nickname;
+
         @JsonProperty("profile_image_url")
         private String profileImageUrl;
     }

--- a/BE/promate/src/main/java/org/example/promate/global/auth/dto/KakaoUserResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/global/auth/dto/KakaoUserResponseDTO.java
@@ -8,4 +8,20 @@ public class KakaoUserResponseDTO {
     
     @JsonProperty("id")
     private Long kakaoId;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    public static class KakaoAccount {
+
+        private Profile profile;
+    }
+
+    @Getter
+    public static class Profile {
+
+        @JsonProperty("profile_image_url")
+        private String profileImageUrl;
+    }
 }

--- a/BE/promate/src/main/java/org/example/promate/global/auth/service/KakaoAuthService.java
+++ b/BE/promate/src/main/java/org/example/promate/global/auth/service/KakaoAuthService.java
@@ -96,8 +96,6 @@ public class KakaoAuthService {
             tokenResult = tokenResponse.getBody();
         } catch (Exception e) {
 
-            e.printStackTrace(); // 디버깅로그
-
             throw new AuthException(AuthErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
         }
 
@@ -127,8 +125,6 @@ public class KakaoAuthService {
             );
             userInfo = userResponse.getBody();
         } catch (Exception e) {
-
-            e.printStackTrace(); // 디버깅로그
             throw new AuthException(AuthErrorCode.KAKAO_USER_INFO_FAILED);
         }
 

--- a/BE/promate/src/main/java/org/example/promate/global/auth/service/KakaoAuthService.java
+++ b/BE/promate/src/main/java/org/example/promate/global/auth/service/KakaoAuthService.java
@@ -144,10 +144,15 @@ public class KakaoAuthService {
                 .getProfile()
                 .getProfileImageUrl();
 
+        String name = userInfo.getKakaoAccount() // 카카오에서 일단 카카오톡 닉네임을 받아오고, 나중에 프로필 수정에서 수정 가능
+                .getProfile()
+                .getNickname();
+
         User user = userRepository.findByKakaoId(kakaoId)
                 .orElseGet(() -> userRepository.save(
                         User.builder()
                                 .kakaoId(kakaoId)
+                                .name(name)
                                 .isProfileCompleted(false)
                                 .profileImageUrl(profileImageUrl)
                                 .build()

--- a/BE/promate/src/main/java/org/example/promate/global/auth/service/KakaoAuthService.java
+++ b/BE/promate/src/main/java/org/example/promate/global/auth/service/KakaoAuthService.java
@@ -140,11 +140,16 @@ public class KakaoAuthService {
 
         Long kakaoId = userInfo.getKakaoId();
 
+        String profileImageUrl = userInfo.getKakaoAccount()
+                .getProfile()
+                .getProfileImageUrl();
+
         User user = userRepository.findByKakaoId(kakaoId)
                 .orElseGet(() -> userRepository.save(
                         User.builder()
                                 .kakaoId(kakaoId)
                                 .isProfileCompleted(false)
+                                .profileImageUrl(profileImageUrl)
                                 .build()
                 ));
 


### PR DESCRIPTION
## 📌 개요
user의 프로필 관련 기능들을 추가하였습니다.

## ⚙️ 작업 내용
- user 카카오 프로필 이미지, 닉네임 저장 기능
- user 프로젝트 정보(직접 작성, 기존 프로젝트 불러오기) 조회 기능
- user와 관련된 에러코드와 성공코드를 추가하였습니다.
 
## 🎸 기타사항
프로필 이미지와 닉네임은 카카오톡에 설정된 것을 가입 시에 기본값으로 받아오며, 닉네임은 가입 후 수정 가능합니다.
