### PR TITLE
[feat] 프로필 연동 지원서, 지원글 Task 조회, 북마크 기능 구현, 배포 트러블 이슈 해결

### DIFF
--- a/BE/promate/build.gradle
+++ b/BE/promate/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    testImplementation 'com.h2database:h2'
 }
 
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
@@ -79,3 +81,5 @@ clean {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+

--- a/BE/promate/src/main/java/org/example/promate/PromateApplication.java
+++ b/BE/promate/src/main/java/org/example/promate/PromateApplication.java
@@ -2,10 +2,13 @@ package org.example.promate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
 @EnableJpaAuditing
+@SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
+//UserDetailsServiceAutoConfiguration은 Spring Boot가 자동으로 ID/PW 기반 로그인 시스템을 세팅하는 클래스입니다.
+//제외하지 않을 경우, → 기본 인증 시스템 자동 생성 → SecurityConfig와 충돌
 public class PromateApplication {
 
     public static void main(String[] args) {

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/dto/ApplicationDetailResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/dto/ApplicationDetailResponse.java
@@ -2,6 +2,7 @@ package org.example.promate.domain.apply.dto;
 
 import org.example.promate.domain.apply.enums.Status;
 import org.example.promate.domain.recruit.enums.Category;
+import org.example.promate.domain.workspace.entity.Task;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -11,6 +12,7 @@ public record ApplicationDetailResponse(
         Long applicationId,
         ApplicantProfile applicant,
         String introduction,
+        String contributionArea,
         LocalDateTime appliedAt,
         Status status,
         List<PastProjectInfo> pastProjects
@@ -18,13 +20,15 @@ public record ApplicationDetailResponse(
     public record ApplicantProfile(
             String name,
             BigDecimal mannerTemperature,
-            BigDecimal sincerityTemperature,
-            String profileImageUrl
+            BigDecimal sincerityTemperature
     ) {}
 
     public record PastProjectInfo(
             Long projectId,
             String title,
-            Category category
-    ) {}
+            String type, //프로젝트 이력 구분을 위함
+            List<String> taskNames,
+            String selfTaskDescription
+    ) {} //ProMate 프로젝트 -> taskNames 입력, selfTaskDescription NULL
+    // 수동 입력 프로젝트 -> taskNames NULL , selfTaskDescription 입력
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/dto/ApplyRequest.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/dto/ApplyRequest.java
@@ -1,11 +1,19 @@
 package org.example.promate.domain.apply.dto;
 
-import jakarta.validation.constraints.NotBlank;
-
+import lombok.Getter;
 import java.util.List;
 
-public record ApplyRequest(
-        @NotBlank String preferredRole,
-        @NotBlank String introduction,
-        List<Long> selectedProjectIds
-) {}
+@Getter
+public class ApplyRequest {
+
+    private String preferredRole;
+    private String introduction;
+    private List<SelectedProjectDTO> selectedProjectIds;
+
+    @Getter
+    public static class SelectedProjectDTO {
+        private Long projectId; // 시스템 혹은 수동 프로젝트의 ID
+        private boolean isManual; // 수동 여부 플래그
+    }
+}
+

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/entity/ApplyProject.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/entity/ApplyProject.java
@@ -1,15 +1,12 @@
 package org.example.promate.domain.apply.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.example.promate.domain.project.entity.Project;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA를 위한 최소한의 접근 허용
 public class ApplyProject {
 
 
@@ -28,8 +25,24 @@ public class ApplyProject {
     private Project project;
 
     @Builder
-    public ApplyProject(Apply apply, Project project) {
+    public ApplyProject(Apply apply, Project project, Long promateProjectId ,Long manualProjectId, boolean isManual) {
         this.apply = apply;
         this.project = project;
+        this.promateProjectId = promateProjectId; // 시스템 프로젝트일 경우 (null 가능)
+        this.manualProjectId = manualProjectId; // 수동 프로젝트일 경우 (null 가능)
+        this.isManual = isManual;
+    }
+
+    private boolean isManual; // true: 수동 입력한 프로젝트임 , false: ProMate에서 불러온 프로젝트임.
+
+    // 프로메이트로 수행한 프로젝트일 경우의 연관관계
+    private Long promateProjectId;
+
+    // 수동 입력 프로젝트일 경우의 연관관계
+    private Long manualProjectId;
+
+    // 프로젝트 타입 조회용 메서드 (응답 시 활용)
+    public String getProjectType() {
+        return isManual ? "MANUAL" : "PROMATE";
     }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/entity/ApplyProject.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/entity/ApplyProject.java
@@ -6,12 +6,9 @@ import org.example.promate.domain.project.entity.Project;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA를 위한 최소한의 접근 허용
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ApplyProject {
 
-
-    //지원서 1개는 여러 가지 프로젝트 포함 가능 / 프로젝트 1개는 여러 지원서에 채택 가능
-    //다대다 관계를 표현하기 위한 매핑 클래스임
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -20,28 +17,24 @@ public class ApplyProject {
     @JoinColumn(name= "apply_id")
     private Apply apply;
 
+    // PROMATE 프로젝트일 경우 객체 그래프 탐색을 위해 매핑 (null 가능)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id")
     private Project project;
 
+    private boolean isManual; // true: 수동 입력(UserProjectHistory), false: ProMate 프로젝트
+
+    // 수동 입력 프로젝트일 경우, 테이블 PK 보관 (null 가능)
+    private Long manualProjectId;
+
     @Builder
-    public ApplyProject(Apply apply, Project project, Long promateProjectId ,Long manualProjectId, boolean isManual) {
+    public ApplyProject(Apply apply, Project project, Long manualProjectId, boolean isManual) {
         this.apply = apply;
         this.project = project;
-        this.promateProjectId = promateProjectId; // 시스템 프로젝트일 경우 (null 가능)
-        this.manualProjectId = manualProjectId; // 수동 프로젝트일 경우 (null 가능)
+        this.manualProjectId = manualProjectId;
         this.isManual = isManual;
     }
 
-    private boolean isManual; // true: 수동 입력한 프로젝트임 , false: ProMate에서 불러온 프로젝트임.
-
-    // 프로메이트로 수행한 프로젝트일 경우의 연관관계
-    private Long promateProjectId;
-
-    // 수동 입력 프로젝트일 경우의 연관관계
-    private Long manualProjectId;
-
-    // 프로젝트 타입 조회용 메서드 (응답 시 활용)
     public String getProjectType() {
         return isManual ? "MANUAL" : "PROMATE";
     }

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/repository/ApplyRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/repository/ApplyRepository.java
@@ -32,4 +32,6 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
 
     void deleteAllByRecruitId(Long id);
+
+    List<Apply> findByUserIdAndRecruitIdIn(Long userId, List<Long> recruitIds);
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/service/ApplyService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/service/ApplyService.java
@@ -6,17 +6,22 @@ import org.example.promate.domain.apply.entity.ApplyProject;
 import org.example.promate.domain.apply.enums.Status;
 import org.example.promate.domain.apply.repository.ApplicationProjectRepository;
 import org.example.promate.domain.apply.repository.ApplyRepository;
+import org.example.promate.domain.project.entity.ManualProject;
 import org.example.promate.domain.project.entity.Member;
 import org.example.promate.domain.project.entity.Project;
 import org.example.promate.domain.project.enums.Position;
+import org.example.promate.domain.project.repository.ManualProjectRepository;
 import org.example.promate.domain.project.repository.MemberRepository;
 import org.example.promate.domain.project.repository.ProjectRepository;
 import org.example.promate.domain.recruit.entity.Recruit;
 import org.example.promate.domain.recruit.enums.RecruitStatus;
 import org.example.promate.domain.recruit.repository.RecruitRepository;
 import org.example.promate.domain.user.entity.User;
+import org.example.promate.domain.user.exception.UserErrorCode;
 import org.example.promate.domain.user.repository.UserRepository;
 import org.example.promate.domain.recruit.code.RecruitErrorCode;
+import org.example.promate.domain.workspace.entity.Task;
+import org.example.promate.domain.workspace.repository.TaskRepository;
 import org.example.promate.global.ApiPayload.exception.GeneralException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +40,8 @@ public class ApplyService {
     private final RecruitRepository recruitRepository;
     private final ProjectRepository projectRepository;
     private final MemberRepository memberRepository;
+    private final TaskRepository taskRepository;
+    private final ManualProjectRepository manualProjectRepository;
 
     public ApplyFormResponse getApplyForm(Long recruitmentId, Long userId) {
         // 모집글 제목을 위한 조회 (Soft Delete 고려)
@@ -75,18 +82,21 @@ public class ApplyService {
         Apply application = Apply.builder()
                 .user(user)
                 .recruit(recruit)
-                .objective(request.preferredRole())
-                .prContent(request.introduction())
+                .objective(request.getPreferredRole())
+                .prContent(request.getIntroduction())
                 .status(Status.PENDING)
                 .build();
         applyRepository.save(application);
 
         // 선택한 프로젝트 이력 매핑 저장
-        if (request.selectedProjectIds() != null && !request.selectedProjectIds().isEmpty()) {
-            List<Project> projects = projectRepository.findAllById(request.selectedProjectIds());
-
-            List<ApplyProject> mappings = projects.stream()
-                    .map(p -> new ApplyProject(application, p))
+        if (request.getSelectedProjectIds() != null && !request.getSelectedProjectIds().isEmpty()) {
+            List<ApplyProject> mappings = request.getSelectedProjectIds().stream()
+                    .map(projectDto -> ApplyProject.builder()
+                            .apply(application)
+                            .isManual(projectDto.isManual())
+                            .promateProjectId(projectDto.isManual() ? null : projectDto.getProjectId())
+                            .manualProjectId(projectDto.isManual() ? projectDto.getProjectId() : null)
+                            .build())
                     .toList();
             applyProjectRepository.saveAll(mappings);
         }
@@ -182,7 +192,8 @@ public class ApplyService {
         return new ApplicantListResponse(recruit.getId(), recruit.getTitle(), summaries.size(), summaries);
     }
 
-    // 2. 지원서 상세 조회
+
+    // 지원서 상세 조회
     public ApplicationDetailResponse getApplicationDetail(Long recruitmentId, Long applicationId, Long leaderId) {
         // 모집글 존재 확인 및 권한 검증
         Recruit recruit = recruitRepository.findById(recruitmentId)
@@ -196,25 +207,48 @@ public class ApplyService {
         Apply apply = applyRepository.findByIdWithUserAndProjects(applicationId)
                 .orElseThrow(() -> new GeneralException(RecruitErrorCode.RECRUITMENT_NOT_FOUND));
 
-        // DTO 변환
+        List<ApplicationDetailResponse.PastProjectInfo> pastProjects = apply.getApplyProjects().stream()
+                .map(ap -> {
+                    if (!ap.isManual()) { //applyProject의 isManual 컬럼 값으로 분기
+                        // ProMate 프로젝트 태스크 목록 조회
+                        List<String> taskNames = taskRepository.findAllByProjectIdAndMemberId(
+                                ap.getProject().getId(), apply.getUser().getId()
+                        ).stream().map(Task::getTitle).toList();
+
+                        return new ApplicationDetailResponse.PastProjectInfo(
+                                ap.getProject().getId(),
+                                ap.getProject().getTitle(),
+                                "PROMATE",
+                                taskNames,
+                                null
+                        );
+                    } else {
+                        // 수동 입력 프로젝트 <- 테스크 목록 대신 50자 이내의 글 가져오기
+                        ManualProject manualProject = manualProjectRepository.findById(ap.getManualProjectId())
+                                .orElseThrow(() -> new GeneralException(UserErrorCode.PROJECT_NOT_FOUND));
+
+                        return new ApplicationDetailResponse.PastProjectInfo(
+                                ap.getManualProjectId(),
+                                manualProject.getTitle(),
+                                "MANUAL",
+                                null,
+                                manualProject.getTaskDescription()// 50자 정도의 String
+                        );
+                    }
+                }).toList();
+
+        //최종 DTO 조립
         ApplicationDetailResponse.ApplicantProfile profile = new ApplicationDetailResponse.ApplicantProfile(
                 apply.getUser().getName(),
                 apply.getUser().getMannerTemp(),
-                apply.getUser().getDiligenceTemp(),
-                apply.getUser().getProfileImageUrl()
+                apply.getUser().getDiligenceTemp()
         );
-
-        List<ApplicationDetailResponse.PastProjectInfo> pastProjects = apply.getApplyProjects().stream()
-                .map(ap -> new ApplicationDetailResponse.PastProjectInfo(
-                        ap.getProject().getId(),
-                        ap.getProject().getTitle(),
-                        recruit.getCategory()
-                )).toList();
 
         return new ApplicationDetailResponse(
                 apply.getId(),
                 profile,
                 apply.getPrContent(),
+                apply.getObjective(),
                 apply.getCreatedAt(),
                 apply.getStatus(),
                 pastProjects

--- a/BE/promate/src/main/java/org/example/promate/domain/apply/service/ApplyService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/service/ApplyService.java
@@ -6,18 +6,18 @@ import org.example.promate.domain.apply.entity.ApplyProject;
 import org.example.promate.domain.apply.enums.Status;
 import org.example.promate.domain.apply.repository.ApplicationProjectRepository;
 import org.example.promate.domain.apply.repository.ApplyRepository;
-import org.example.promate.domain.project.entity.ManualProject;
 import org.example.promate.domain.project.entity.Member;
 import org.example.promate.domain.project.entity.Project;
 import org.example.promate.domain.project.enums.Position;
-import org.example.promate.domain.project.repository.ManualProjectRepository;
 import org.example.promate.domain.project.repository.MemberRepository;
 import org.example.promate.domain.project.repository.ProjectRepository;
 import org.example.promate.domain.recruit.entity.Recruit;
 import org.example.promate.domain.recruit.enums.RecruitStatus;
 import org.example.promate.domain.recruit.repository.RecruitRepository;
 import org.example.promate.domain.user.entity.User;
+import org.example.promate.domain.user.entity.UserProjectHistory;
 import org.example.promate.domain.user.exception.UserErrorCode;
+import org.example.promate.domain.user.repository.UserProjectHistoryRepository;
 import org.example.promate.domain.user.repository.UserRepository;
 import org.example.promate.domain.recruit.code.RecruitErrorCode;
 import org.example.promate.domain.workspace.entity.Task;
@@ -25,9 +25,7 @@ import org.example.promate.domain.workspace.repository.TaskRepository;
 import org.example.promate.global.ApiPayload.exception.GeneralException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
-
 
 @Service
 @Transactional(readOnly = true)
@@ -41,7 +39,8 @@ public class ApplyService {
     private final ProjectRepository projectRepository;
     private final MemberRepository memberRepository;
     private final TaskRepository taskRepository;
-    private final ManualProjectRepository manualProjectRepository;
+    private final UserProjectHistoryRepository userProjectHistoryRepository;
+
 
     public ApplyFormResponse getApplyForm(Long recruitmentId, Long userId) {
         // 모집글 제목을 위한 조회 (Soft Delete 고려)
@@ -71,9 +70,10 @@ public class ApplyService {
 
         validateRecruitingStatus(recruit);
 
-        User user = userRepository.findById(userId).get();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
-        // 지원서 Status가 PENDING 아닌 상태라면 지원 차단
+        // 모집글 Status가 RECRUITING 아닌 상태라면 지원 차단
         if (recruit.getStatus() != RecruitStatus.RECRUITING) {
             throw new GeneralException(RecruitErrorCode.RECRUITMENT_ALREADY_CLOSED);
         }
@@ -91,12 +91,20 @@ public class ApplyService {
         // 선택한 프로젝트 이력 매핑 저장
         if (request.getSelectedProjectIds() != null && !request.getSelectedProjectIds().isEmpty()) {
             List<ApplyProject> mappings = request.getSelectedProjectIds().stream()
-                    .map(projectDto -> ApplyProject.builder()
-                            .apply(application)
-                            .isManual(projectDto.isManual())
-                            .promateProjectId(projectDto.isManual() ? null : projectDto.getProjectId())
-                            .manualProjectId(projectDto.isManual() ? projectDto.getProjectId() : null)
-                            .build())
+                    .map(projectDto -> {
+                        ApplyProject.ApplyProjectBuilder builder = ApplyProject.builder()
+                                .apply(application)
+                                .isManual(projectDto.isManual());
+
+                        if (projectDto.isManual()) {
+                            // 수동 프로젝트는 UserProjectHistory ID만 저장
+                            builder.manualProjectId(projectDto.getProjectId());
+                        } else {
+                            Project project = projectRepository.getReferenceById(projectDto.getProjectId());
+                            builder.project(project);
+                        }
+                        return builder.build();
+                    })
                     .toList();
             applyProjectRepository.saveAll(mappings);
         }
@@ -209,7 +217,7 @@ public class ApplyService {
 
         List<ApplicationDetailResponse.PastProjectInfo> pastProjects = apply.getApplyProjects().stream()
                 .map(ap -> {
-                    if (!ap.isManual()) { //applyProject의 isManual 컬럼 값으로 분기
+                    if (!ap.isManual()) {
                         // ProMate 프로젝트 태스크 목록 조회
                         List<String> taskNames = taskRepository.findAllByProjectIdAndMemberId(
                                 ap.getProject().getId(), apply.getUser().getId()
@@ -223,16 +231,16 @@ public class ApplyService {
                                 null
                         );
                     } else {
-                        // 수동 입력 프로젝트 <- 테스크 목록 대신 50자 이내의 글 가져오기
-                        ManualProject manualProject = manualProjectRepository.findById(ap.getManualProjectId())
-                                .orElseThrow(() -> new GeneralException(UserErrorCode.PROJECT_NOT_FOUND));
+                        // 수동 입력 프로젝트 UserProjectHistory
+                        UserProjectHistory userProjectHistory = userProjectHistoryRepository.findById(ap.getManualProjectId())
+                                .orElseThrow(() -> new GeneralException(UserErrorCode.PROJECT_HISTORY_NOT_FOUND));
 
                         return new ApplicationDetailResponse.PastProjectInfo(
                                 ap.getManualProjectId(),
-                                manualProject.getTitle(),
+                                userProjectHistory.getProjectName(), // title -> projectName 변경
                                 "MANUAL",
                                 null,
-                                manualProject.getTaskDescription()// 50자 정도의 String
+                                userProjectHistory.getDescription()  // taskDescription -> description 변경
                         );
                     }
                 }).toList();
@@ -325,3 +333,5 @@ public class ApplyService {
         applyRepository.delete(apply); // 공통 로직 : 지원서 삭제
     }
 }
+
+

--- a/BE/promate/src/main/java/org/example/promate/domain/project/entity/ManualProject.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/entity/ManualProject.java
@@ -1,0 +1,30 @@
+package org.example.promate.domain.project.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.promate.domain.user.entity.User;
+
+
+//promate에서 수행한 프로젝트가 아닌, 수동 입력한 가상 프로젝트
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ManualProject {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String title; // 프로젝트명
+    private String period; // 기간
+
+    @Column(length = 50)
+    private String taskDescription; //테스크 불러오는 대신 50자 이내의 설명 적기
+
+    private String role;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/project/repository/ManualProjectRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/repository/ManualProjectRepository.java
@@ -1,0 +1,7 @@
+package org.example.promate.domain.project.repository;
+
+import org.example.promate.domain.project.entity.ManualProject;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ManualProjectRepository extends JpaRepository<ManualProject,Long> {
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/code/RecruitSuccessCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/code/RecruitSuccessCode.java
@@ -11,18 +11,19 @@ public enum RecruitSuccessCode implements BaseSuccessCode {
 
     RECRUITMENT_CREATED(HttpStatus.CREATED, "RECRUIT_S001", "팀 모집 게시글 발행을 성공했습니다."),
     RECRUITMENT_FOUND(HttpStatus.OK, "RECRUIT_S002", "팀 모집글 상세 조회를 성공했습니다."),
-    RECRUITMENT_UPDATED(HttpStatus.OK, "RECRUIT_S003", "팀 모집글 수정을 성공했습니다 ."),
-    RECRUITMENT_DELETED(HttpStatus.NO_CONTENT, "RECRUIT_S004", "팀 모집글 삭제를 성공했습니다 ."),
-    RECRUITMENT_FILTERED(HttpStatus.NO_CONTENT, "RECRUIT_S005", "팀 모집글 필터링을 성공했습니다 ."),
+    RECRUITMENT_UPDATED(HttpStatus.OK, "RECRUIT_S003", "팀 모집글 수정을 성공했습니다."),
+    RECRUITMENT_DELETED(HttpStatus.NO_CONTENT, "RECRUIT_S004", "팀 모집글 삭제를 성공했습니다."),
+    RECRUITMENT_FILTERED(HttpStatus.NO_CONTENT, "RECRUIT_S005", "팀 모집글 필터링을 성공했습니다."),
+    RECRUITMENT_BOOKMARKED(HttpStatus.NO_CONTENT, "RECRUIT_S006", "팀 모집글 북마크를 성공했습니다."),
 
-    APPLY_FORM_LOADED(HttpStatus.OK, "RECRUIT_S006", "팀 지원글 작성 페이지 불러오기를 성공했습니다."),
-    APPLY_FORM_SUBMITTED(HttpStatus.OK, "RECRUIT_S007", "팀 지원글 발행을 성공했습니다."),
-    APPLY_FORM_UPDATED(HttpStatus.OK, "RECRUIT_S008", "팀 지원글 수정을 성공했습니다."),
-    APPLY_FORM_DELETED(HttpStatus.NO_CONTENT, "RECRUIT_S009", "팀 지원글 삭제를 성공했습니다."),
+    APPLY_FORM_LOADED(HttpStatus.OK, "RECRUIT_S007", "팀 지원글 작성 페이지 불러오기를 성공했습니다."),
+    APPLY_FORM_SUBMITTED(HttpStatus.OK, "RECRUIT_S008", "팀 지원글 발행을 성공했습니다."),
+    APPLY_FORM_UPDATED(HttpStatus.OK, "RECRUIT_S009", "팀 지원글 수정을 성공했습니다."),
+    APPLY_FORM_DELETED(HttpStatus.NO_CONTENT, "RECRUIT_S010", "팀 지원글 삭제를 성공했습니다."),
 
-    APPLY_LIST_FETCHED(HttpStatus.OK,"RECRUIT_S010", "팀 지원서 리스트 불러오기를 성공했습니다."),
-    APPLY_DETAIL_FETCHED(HttpStatus.OK, "RECRUIT_S011", "팀 지원서 상세 조회를 성공했습니다."),
-    APPLY_STATUS_UPDATED(HttpStatus.OK, "RECRUIT_S012", "팀 모집이 완료되었습니다.")
+    APPLY_LIST_FETCHED(HttpStatus.OK,"RECRUIT_S011", "팀 지원서 리스트 불러오기를 성공했습니다."),
+    APPLY_DETAIL_FETCHED(HttpStatus.OK, "RECRUIT_S012", "팀 지원서 상세 조회를 성공했습니다."),
+    APPLY_STATUS_UPDATED(HttpStatus.OK, "RECRUIT_S013", "팀 모집이 완료되었습니다.")
     ;
 
     private final HttpStatus status;

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/code/RecruitSuccessCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/code/RecruitSuccessCode.java
@@ -15,15 +15,16 @@ public enum RecruitSuccessCode implements BaseSuccessCode {
     RECRUITMENT_DELETED(HttpStatus.NO_CONTENT, "RECRUIT_S004", "팀 모집글 삭제를 성공했습니다."),
     RECRUITMENT_FILTERED(HttpStatus.NO_CONTENT, "RECRUIT_S005", "팀 모집글 필터링을 성공했습니다."),
     RECRUITMENT_BOOKMARKED(HttpStatus.NO_CONTENT, "RECRUIT_S006", "팀 모집글 북마크를 성공했습니다."),
+    RECRUITMENT_BOOKMARKED_LIST_FETCHED(HttpStatus.OK,"RECRUIT_S007", "북마크된 모집글 리스트 불러오기를 성공했습니다."),
 
-    APPLY_FORM_LOADED(HttpStatus.OK, "RECRUIT_S007", "팀 지원글 작성 페이지 불러오기를 성공했습니다."),
-    APPLY_FORM_SUBMITTED(HttpStatus.OK, "RECRUIT_S008", "팀 지원글 발행을 성공했습니다."),
-    APPLY_FORM_UPDATED(HttpStatus.OK, "RECRUIT_S009", "팀 지원글 수정을 성공했습니다."),
-    APPLY_FORM_DELETED(HttpStatus.NO_CONTENT, "RECRUIT_S010", "팀 지원글 삭제를 성공했습니다."),
+    APPLY_FORM_LOADED(HttpStatus.OK, "RECRUIT_S008", "팀 지원글 작성 페이지 불러오기를 성공했습니다."),
+    APPLY_FORM_SUBMITTED(HttpStatus.OK, "RECRUIT_S009", "팀 지원글 발행을 성공했습니다."),
+    APPLY_FORM_UPDATED(HttpStatus.OK, "RECRUIT_S010", "팀 지원글 수정을 성공했습니다."),
+    APPLY_FORM_DELETED(HttpStatus.NO_CONTENT, "RECRUIT_S011", "팀 지원글 삭제를 성공했습니다."),
 
-    APPLY_LIST_FETCHED(HttpStatus.OK,"RECRUIT_S011", "팀 지원서 리스트 불러오기를 성공했습니다."),
-    APPLY_DETAIL_FETCHED(HttpStatus.OK, "RECRUIT_S012", "팀 지원서 상세 조회를 성공했습니다."),
-    APPLY_STATUS_UPDATED(HttpStatus.OK, "RECRUIT_S013", "팀 모집이 완료되었습니다.")
+    APPLY_LIST_FETCHED(HttpStatus.OK,"RECRUIT_S012", "팀 지원서 리스트 불러오기를 성공했습니다."),
+    APPLY_DETAIL_FETCHED(HttpStatus.OK, "RECRUIT_S013", "팀 지원서 상세 조회를 성공했습니다."),
+    APPLY_STATUS_UPDATED(HttpStatus.OK, "RECRUIT_S014", "팀 모집이 완료되었습니다.")
     ;
 
     private final HttpStatus status;

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/controller/RecruitController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/controller/RecruitController.java
@@ -98,4 +98,14 @@ public class RecruitController {
         RecruitStatusResponse response = recruitService.changeRecruitStatus(recruitmentId, userId, request);
         return ApiResponse.onSuccess(RecruitSuccessCode.APPLY_STATUS_UPDATED, response);
     }
+
+    @PostMapping("/{recruitmentId}/bookmarks")
+    public ApiResponse<BookmarkResponse> toggleBookmark(
+            @PathVariable Long recruitmentId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        BookmarkResponse data = recruitService.toggleBookmark(recruitmentId, userId);
+        return ApiResponse.onSuccess(RecruitSuccessCode.RECRUITMENT_BOOKMARKED,data);
+    }
+
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/controller/RecruitController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/controller/RecruitController.java
@@ -79,9 +79,10 @@ public class RecruitController {
     @GetMapping
     public ResponseEntity<ApiResponse<RecruitPageResponse<RecruitResponse>>> getRecruitList(
             @ModelAttribute RecruitSearchCondition condition,
+            @AuthenticationPrincipal Long userId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        RecruitPageResponse<RecruitResponse> response = recruitService.getRecruitments(condition, pageable);
+        RecruitPageResponse<RecruitResponse> response = recruitService.getRecruitments(condition, pageable,userId);
 
         return ResponseEntity
                 .status(RecruitSuccessCode.RECRUITMENT_FILTERED.getStatus())
@@ -99,7 +100,7 @@ public class RecruitController {
         return ApiResponse.onSuccess(RecruitSuccessCode.APPLY_STATUS_UPDATED, response);
     }
 
-    @PostMapping("/{recruitmentId}/bookmarks")
+    @PostMapping("/{recruitmentId}/bookmark")
     public ApiResponse<BookmarkResponse> toggleBookmark(
             @PathVariable Long recruitmentId,
             @AuthenticationPrincipal Long userId
@@ -108,4 +109,13 @@ public class RecruitController {
         return ApiResponse.onSuccess(RecruitSuccessCode.RECRUITMENT_BOOKMARKED,data);
     }
 
+    @GetMapping("/bookmark")
+    public ApiResponse<RecruitPageResponse<RecruitResponse>> getBookmarkList(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    )
+    {
+        RecruitPageResponse<RecruitResponse> response = recruitService.getBookmarkedRecruitments(userId, pageable);
+        return ApiResponse.onSuccess(RecruitSuccessCode.RECRUITMENT_BOOKMARKED_LIST_FETCHED,response);
+    }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/BookmarkResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/BookmarkResponse.java
@@ -1,0 +1,6 @@
+package org.example.promate.domain.recruit.dto.response;
+
+public record BookmarkResponse(
+        Long recruitmentId,  // 관심 설정할 게시글의 고유 ID
+        boolean isBookmarked // true: 관심 등록됨, false: 관심 해제됨
+) {}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitResponse.java
@@ -1,5 +1,7 @@
 package org.example.promate.domain.recruit.dto.response;
 
+import org.example.promate.domain.apply.enums.Status;
+import org.example.promate.domain.recruit.entity.Recruit;
 import org.example.promate.domain.recruit.enums.Category;
 import org.example.promate.domain.recruit.enums.RecruitStatus;
 
@@ -13,5 +15,25 @@ public record RecruitResponse(
         LocalDateTime deadline,
         RecruitStatus status,
         int maxMember,
-        int currentMember
-) {}
+        int currentMember,
+        Long projectId,         // 모집글을 통해 개설된 프로젝트 ID (개설 전이면 null)
+        Status myApplyStatus,   // 본인의 지원 상태 (PENDING, ACCEPTED, REJECTED / 지원 안 했으면 null)
+        Long myApplicationId    // 본인의 지원서 ID (지원 안 했으면 null)
+) {
+    public static RecruitResponse of(Recruit recruit, Status myApplyStatus, Long myApplicationId) {
+        return new RecruitResponse(
+                recruit.getId(),
+                recruit.getTitle(),
+                recruit.getCategory(),
+                recruit.getCreatedAt(),
+                recruit.getDeadline(),
+                recruit.getStatus(),
+                recruit.getTotalSlots(),
+                recruit.getJoinedCount(),
+                // Project 엔티티 연관관계가 있다면 ID 추출, 없으면 null
+                recruit.getProject() != null ? recruit.getProject().getId() : null,
+                myApplyStatus,
+                myApplicationId
+        );
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/entity/Bookmark.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/entity/Bookmark.java
@@ -1,0 +1,33 @@
+package org.example.promate.domain.recruit.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.promate.domain.user.entity.User;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "recruit_id"})
+        }
+)
+public class Bookmark {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruit_id")
+    private Recruit recruit;
+
+    public Bookmark(User user, Recruit recruit) {
+        this.user = user;
+        this.recruit = recruit;
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/BookmarkRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/BookmarkRepository.java
@@ -1,0 +1,12 @@
+package org.example.promate.domain.recruit.repository;
+
+import org.example.promate.domain.recruit.entity.Bookmark;
+import org.example.promate.domain.recruit.entity.Recruit;
+import org.example.promate.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark,Long> {
+    Optional<Bookmark> findByUserAndRecruit(User user, Recruit recruit);
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/BookmarkRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/BookmarkRepository.java
@@ -3,10 +3,18 @@ package org.example.promate.domain.recruit.repository;
 import org.example.promate.domain.recruit.entity.Bookmark;
 import org.example.promate.domain.recruit.entity.Recruit;
 import org.example.promate.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark,Long> {
     Optional<Bookmark> findByUserAndRecruit(User user, Recruit recruit);
+
+    @Query(value = "select b from Bookmark b join fetch b.recruit where b.user.id = :userId",
+            countQuery = "select count(b) from Bookmark b where b.user.id = :userId")
+    Page<Bookmark> findByUserIdWithRecruit(@Param("userId") Long userId, Pageable pageable);
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepositoryCustom.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepositoryCustom.java
@@ -1,10 +1,10 @@
 package org.example.promate.domain.recruit.repository;
 
 import org.example.promate.domain.recruit.dto.request.RecruitSearchCondition;
-import org.example.promate.domain.recruit.dto.response.RecruitResponse;
+import org.example.promate.domain.recruit.entity.Recruit;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface RecruitRepositoryCustom {
-    Page<RecruitResponse> searchRecruits(RecruitSearchCondition condition, Pageable pageable);
+    Page<Recruit> searchRecruits(RecruitSearchCondition condition, Pageable pageable);
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepositoryImpl.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepositoryImpl.java
@@ -1,12 +1,10 @@
 package org.example.promate.domain.recruit.repository;
-
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.example.promate.domain.recruit.dto.request.RecruitSearchCondition;
-import org.example.promate.domain.recruit.dto.response.RecruitResponse;
+import org.example.promate.domain.recruit.entity.Recruit;
 import org.example.promate.domain.recruit.enums.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,29 +23,19 @@ public class RecruitRepositoryImpl implements RecruitRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<RecruitResponse> searchRecruits(RecruitSearchCondition condition, Pageable pageable) {
+    public Page<Recruit> searchRecruits(RecruitSearchCondition condition, Pageable pageable) {
 
-        // 데이터 조회 쿼리
-        List<RecruitResponse> content = queryFactory
-                .select(Projections.constructor(RecruitResponse.class,
-                        recruit.id,
-                        recruit.title,
-                        recruit.category,
-                        recruit.createdAt,
-                        recruit.deadline,
-                        recruit.status,
-                        recruit.totalSlots,
-                        recruit.joinedCount
-                ))
+        List<Recruit> content = queryFactory
+                .select(recruit)
                 .from(recruit)
                 .where(
-                        recruit.isDeleted.isFalse(),
+                        recruit.isDeleted.isFalse(), // 삭제되지 않은 게시글만
                         containsSearch(condition.search()),
                         eqCategory(condition.category())
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(recruit.createdAt.desc()) //기본값: 최신순
+                .orderBy(recruit.createdAt.desc()) // 최신순 정렬
                 .fetch();
 
         // 전체 카운트 쿼리
@@ -55,6 +43,7 @@ public class RecruitRepositoryImpl implements RecruitRepositoryCustom {
                 .select(recruit.count())
                 .from(recruit)
                 .where(
+                        recruit.isDeleted.isFalse(), // 카운트 쿼리에도 삭제 플래그 조건
                         containsSearch(condition.search()),
                         eqCategory(condition.category())
                 );

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
@@ -13,8 +13,10 @@ import org.example.promate.domain.recruit.dto.request.RecruitSearchCondition;
 import org.example.promate.domain.recruit.dto.request.RecruitStatusRequest;
 import org.example.promate.domain.recruit.dto.request.RecruitUpdateRequest;
 import org.example.promate.domain.recruit.dto.response.*;
+import org.example.promate.domain.recruit.entity.Bookmark;
 import org.example.promate.domain.recruit.entity.Recruit;
 import org.example.promate.domain.recruit.enums.RecruitStatus;
+import org.example.promate.domain.recruit.repository.BookmarkRepository;
 import org.example.promate.domain.recruit.repository.RecruitRepository;
 import org.example.promate.domain.user.entity.User;
 import org.example.promate.domain.user.exception.UserErrorCode;
@@ -26,6 +28,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -36,6 +40,7 @@ public class RecruitService {
     private final ApplyRepository applyRepository; // 지원 내역 확인용
     private final ProjectRepository projectRepository;
     private final MemberRepository memberRepository;
+    private final BookmarkRepository bookmarkRepository;
 
     @Transactional
     public RecruitCreateResponse createRecruitment(
@@ -183,5 +188,26 @@ public class RecruitService {
         recruitRepository.delete(recruit);
 
         return new RecruitStatusResponse(project.getId(), RecruitStatus.COMPLETED);
+    }
+
+    public BookmarkResponse toggleBookmark(Long recruitmentId, Long userId) {
+        // 게시글 존재 확인
+        Recruit recruit = recruitRepository.findById(recruitmentId)
+                .orElseThrow(() -> new GeneralException(RecruitErrorCode.RECRUITMENT_NOT_FOUND));
+
+        User user = userRepository.getReferenceById(userId);
+
+        // 이미 북마크했는지 확인
+        Optional<Bookmark> optionalBookmark = bookmarkRepository.findByUserAndRecruit(user, recruit);
+
+        if (optionalBookmark.isPresent()) {
+            // 이미 있다면 북마크 취소
+            bookmarkRepository.delete(optionalBookmark.get());
+            return new BookmarkResponse(recruitmentId, false);
+        } else {
+            // 없다면 북마크 등록
+            bookmarkRepository.save(new Bookmark(user, recruit));
+            return new BookmarkResponse(recruitmentId, true);
+        }
     }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
@@ -1,6 +1,7 @@
 package org.example.promate.domain.recruit.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.apply.entity.Apply;
 import org.example.promate.domain.apply.repository.ApplyRepository;
 import org.example.promate.domain.project.entity.Member;
 import org.example.promate.domain.project.entity.Project;
@@ -24,11 +25,13 @@ import org.example.promate.domain.user.repository.UserRepository;
 import org.example.promate.domain.recruit.code.RecruitErrorCode;
 import org.example.promate.global.ApiPayload.exception.GeneralException;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -136,9 +139,18 @@ public class RecruitService {
         recruit.delete();
     }
 
-    public RecruitPageResponse<RecruitResponse> getRecruitments(RecruitSearchCondition condition, Pageable pageable) {
 
-        Page<RecruitResponse> resultPage = recruitRepository.searchRecruits(condition, pageable);
+    /* userId는 보안 검증 X , 로직 분기용(모집글 조회 시 지원 상태 제공)
+    userId != null (로그인 유저) -> 쿼리를 날려 심사중, 합격 등 상태를 채워줌
+    userId == null (비로그인 유저) -> 지원 상태를 전부 null로 채움*/
+    public RecruitPageResponse<RecruitResponse> getRecruitments(RecruitSearchCondition condition, Pageable pageable, Long currentUserId) {
+        // 1. 레포지토리에서 순수 엔티티 페이징 데이터 가져오기
+        Page<Recruit> recruitPage = recruitRepository.searchRecruits(condition, pageable);
+
+        // 2. 로그인 유저 상태에 맞게 지원 상태를 결합
+        List<RecruitResponse> dtoList = enrichRecruitmentsWithApplyStatus(recruitPage.getContent(), currentUserId);
+
+        Page<RecruitResponse> resultPage = new PageImpl<>(dtoList, pageable, recruitPage.getTotalElements());
 
         return RecruitPageResponse.of(resultPage);
     }
@@ -209,5 +221,55 @@ public class RecruitService {
             bookmarkRepository.save(new Bookmark(user, recruit));
             return new BookmarkResponse(recruitmentId, true);
         }
+    }
+
+    public RecruitPageResponse<RecruitResponse> getBookmarkedRecruitments(Long currentUserId, Pageable pageable) {
+
+        userRepository.findById(currentUserId).orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        Page<Bookmark> bookmarkPage = bookmarkRepository.findByUserIdWithRecruit(currentUserId, pageable);
+
+        List<Recruit> bookmarkedRecruits = bookmarkPage.getContent().stream()
+                .map(Bookmark::getRecruit)
+                .toList();
+
+        // 상태 결합 함수를 호출
+        List<RecruitResponse> dtoList = enrichRecruitmentsWithApplyStatus(bookmarkedRecruits, currentUserId);
+
+        Page<RecruitResponse> resultPage = new PageImpl<>(dtoList, pageable, bookmarkPage.getTotalElements());
+
+        return RecruitPageResponse.of(resultPage);
+    }
+
+    /* 다른 API에서 사용하는 메서드,
+    1. "북마크 했으나 최종 탈락한 프로젝트는 상세 내역 확인 못 들어가게"
+    2. "팀 찾기 페이지에서 각 모집글 옆에, 본인의 지원 상태(심사 전, 합격, 불합격)를 반환하는 필드 추가"
+
+    해당 분기점 발생을 위해 userId 존재 시, 특정 모집글에 대한 지원글의 status + ID를 가져옴.
+    */
+    private List<RecruitResponse> enrichRecruitmentsWithApplyStatus(List<Recruit> recruits, Long userId) {
+        if (recruits.isEmpty()) return Collections.emptyList();
+
+        Map<Long, Apply> applyMap = new HashMap<>();
+
+        // 로그인한 유저인 경우에만 쿼리로 지원서들을 한 번에 싹 긁어옴
+        if (userId != null) {
+            List<Long> recruitIds = recruits.stream().map(Recruit::getId).toList();
+            List<Apply> myApplies = applyRepository.findByUserIdAndRecruitIdIn(userId, recruitIds);
+            applyMap = myApplies.stream()
+                    .collect(Collectors.toMap(apply -> apply.getRecruit().getId(), apply -> apply));
+        }
+
+        Map<Long, Apply> finalApplyMap = applyMap;
+
+        return recruits.stream().map(recruit -> {
+            Apply myApply = finalApplyMap.get(recruit.getId());
+
+            return RecruitResponse.of(
+                    recruit,
+                    myApply != null ? myApply.getStatus() : null,
+                    myApply != null ? myApply.getId() : null
+            );
+        }).toList();
     }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/user/exception/UserErrorCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/exception/UserErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum UserErrorCode implements BaseErrorCode {
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "해당 유저가 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "해당 유저가 없습니다."),
+    PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND,"USER_002", "프로젝트 내역을 불러올 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
@@ -23,4 +23,6 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             "where t.id = :taskId " +
             "and t.isDeleted = false")
     Optional<Task> findByIdAndIsDeletedFalse(@Param("taskId")Long id);
+
+    List<Task> findAllByProjectIdAndMemberId(Long projectId, Long memberId);
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
@@ -26,4 +26,6 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     int countByProjectIdAndStatus(Long projectId, TaskStatus status);
     int countByProjectIdAndStatusIn(Long projectId, List<TaskStatus> statuses); // 완료, 미완료 task 조회
+
+    List<Task> findAllByProjectIdAndMemberId(Long projectId, Long memberId);
 }

--- a/BE/promate/src/main/java/org/example/promate/global/config/CorsConfig.java
+++ b/BE/promate/src/main/java/org/example/promate/global/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOrigins(List.of("https://promate-kappa.vercel.app", "https://promate.duckdns.org"));
+        config.setAllowedOrigins(List.of("https://promate-kappa.vercel.app", "https://promate.duckdns.org","http://localhost:3000"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/BE/promate/src/main/java/org/example/promate/global/config/SecurityConfig.java
+++ b/BE/promate/src/main/java/org/example/promate/global/config/SecurityConfig.java
@@ -6,13 +6,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.http.HttpMethod;
 
 @Configuration
+@EnableWebSecurity //@EnableWebSecurity는 Spring Security의 웹 보안 기능을 활성화하는 스위치입니다.
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -26,21 +27,17 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS))
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/",
                                 "/login",
                                 "/actuator/health",
-                                "/api/auth/kakao/login",
-                                "/api/auth/kakao/callback",
-                                "/api/auth/kakao/reissue",
-                                "/api/auth/kakao/logout",
+                                "/api/auth/kakao/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"
                         ).permitAll()
                         .anyRequest().authenticated()
-
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/BE/promate/src/test/java/org/example/promate/PromateApplicationTests.java
+++ b/BE/promate/src/test/java/org/example/promate/PromateApplicationTests.java
@@ -2,8 +2,10 @@ package org.example.promate;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class PromateApplicationTests {
 
     @Test

--- a/BE/promate/src/test/resources/application-test.yml
+++ b/BE/promate/src/test/resources/application-test.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    # 테스트는 메모리 DB(H2)를 사용하므로 실제 Azure/GCP 주소가 필요 없습니다.
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ""
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        show_sql: true
+
+# 아래는 에러를 뱉던 환경 변수들을 위한 테스트 전용 가짜 값들입니다.
+JWT_SECRET: "test-secret-key-at-least-32-characters-long"
+KAKAO_REST_API_KEY: "test-kakao-api-key"
+KAKAO_CLIENT_SECRET: "test-kakao-client-secret"
+KAKAO_REDIRECT_URI: "http://localhost:8080/auth/kakao/callback"


### PR DESCRIPTION
1. 백엔드 배포 트러블 : spring security 관련 403에러 수정

- @EnableWebSecurity 추가
- @SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class}) 추가


2. 프로필 기반 통합 지원
- 지원 시 'ProMate 프로젝트'와 '외부 수동 입력 프로젝트'를 동시 선택 가능하도록 구현.

- ApplyProject 수정 : 시스템 데이터는 @ManyToOne 객체 참조로, 외부 데이터는 Long ID 참조.

- isManual 플래그를 통해 데이터 출처 명시.


3. 태스크 조회 : 프로젝트 이력 종류에 따른 분기(Task or String)
- proMate 프젝: 해당 프로젝트 내 유저의 Task 리스트(이름) 추출.

- 직접 입력 프젝: B 도메인의 UserProject에서 50자 요약 설명 추출.

4. 북마크 : Bookmark 엔티티 추가 <- 북마크 취소 시 Hard delete(단순 구조, 중요한 정보X)
