### PR TITLE
[feat] 공통 - 프로필 팝업 UI 및 프로필 아바타 컴포넌트 UI 구현

### DIFF
--- a/FE/.gitignore
+++ b/FE/.gitignore
@@ -23,3 +23,7 @@ dist-ssr
 *.sln
 *.sw?
 .env
+
+# Vite cache
+.vite/
+**/.vite/

--- a/FE/src/assets/icons/closeIcon.svg
+++ b/FE/src/assets/icons/closeIcon.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M18 6L6 18M6 6L18 18" stroke="#ababab" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+</svg>

--- a/FE/src/assets/icons/imageIcon.svg
+++ b/FE/src/assets/icons/imageIcon.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <rect x="6.5" y="6.5" width="11" height="11" rx="1.5" stroke="#ABABAB" stroke-width="1.5"></rect>
+  <path d="M8.5 15.5L11 12.8L12.8 14.7L15.5 11.5" stroke="#ABABAB" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+</svg>

--- a/FE/src/components/ProfileAvatar/ProfileAvatar.css
+++ b/FE/src/components/ProfileAvatar/ProfileAvatar.css
@@ -1,4 +1,5 @@
 .profile-avatar {
+  position: relative;
   box-sizing: border-box;
 
   display: flex;
@@ -11,15 +12,43 @@
   background: #f1f1f1;
   border: 1px solid #ababab;
   border-radius: 50%;
-  overflow: hidden;
 }
 
 .profile-avatar.clickable {
   cursor: pointer;
 }
 
-.profile-avatar img {
+.profile-avatar .default-icon {
   width: 24px;
   height: 24px;
+  object-fit: contain;
+}
+
+.profile-avatar .user-image {
+  width: 100%;
+  height: 100%;
   object-fit: cover;
+  border-radius: 50%;
+}
+
+/* 우측 하단 뱃지 아이콘 스타일 */
+.profile-edit-badge {
+  position: absolute;
+  bottom: -2px;
+  right: -2px;
+  
+  width: 20px;
+  height: 20px;
+  background-color: #ffffff;
+  border: 1px solid #ababab;
+  border-radius: 50%;
+  
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.profile-edit-badge .edit-icon {
+  width: 12px;
+  height: 12px;
 }

--- a/FE/src/components/ProfileAvatar/ProfileAvatar.css
+++ b/FE/src/components/ProfileAvatar/ProfileAvatar.css
@@ -11,9 +11,15 @@
   background: #f1f1f1;
   border: 1px solid #ababab;
   border-radius: 50%;
+  overflow: hidden;
+}
+
+.profile-avatar.clickable {
+  cursor: pointer;
 }
 
 .profile-avatar img {
   width: 24px;
   height: 24px;
+  object-fit: cover;
 }

--- a/FE/src/components/ProfileAvatar/ProfileAvatar.css
+++ b/FE/src/components/ProfileAvatar/ProfileAvatar.css
@@ -1,0 +1,19 @@
+.profile-avatar {
+  box-sizing: border-box;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 54px;
+  height: 54px;
+
+  background: #f1f1f1;
+  border: 1px solid #ababab;
+  border-radius: 50%;
+}
+
+.profile-avatar img {
+  width: 24px;
+  height: 24px;
+}

--- a/FE/src/components/ProfileAvatar/ProfileAvatar.jsx
+++ b/FE/src/components/ProfileAvatar/ProfileAvatar.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import "./ProfileAvatar.css";
+
+function ProfileAvatar({ src, alt = "프로필 이미지" }) {
+  return (
+    <div className="profile-avatar">
+      <img src={src} alt={alt} />
+    </div>
+  );
+}
+
+export default ProfileAvatar;

--- a/FE/src/components/ProfileAvatar/ProfileAvatar.jsx
+++ b/FE/src/components/ProfileAvatar/ProfileAvatar.jsx
@@ -1,10 +1,19 @@
 import React from "react";
 import "./ProfileAvatar.css";
+import profileIcon from "../../assets/icons/profileIcon.svg";
 
-function ProfileAvatar({ src, alt = "프로필 이미지" }) {
+function ProfileAvatar({ src, alt = "프로필 이미지", className = "", onClick, style }) {
+  const displaySrc = src || profileIcon;
+
   return (
-    <div className="profile-avatar">
-      <img src={src} alt={alt} />
+    <div 
+      className={`profile-avatar ${onClick ? "clickable" : ""} ${className}`.trim()}
+      onClick={onClick}
+      style={style}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+    >
+      <img src={displaySrc} alt={alt} />
     </div>
   );
 }

--- a/FE/src/components/ProfileAvatar/ProfileAvatar.jsx
+++ b/FE/src/components/ProfileAvatar/ProfileAvatar.jsx
@@ -1,19 +1,66 @@
-import React from "react";
+import React, { useRef } from "react";
 import "./ProfileAvatar.css";
 import profileIcon from "../../assets/icons/profileIcon.svg";
+import imageIcon from "../../assets/icons/imageIcon.svg";
 
-function ProfileAvatar({ src, alt = "프로필 이미지", className = "", onClick, style }) {
+function ProfileAvatar({ src, alt = "프로필 이미지", className = "", onClick, style, onImageChange }) {
+  const fileInputRef = useRef(null);
   const displaySrc = src || profileIcon;
+  const imageClass = src ? "user-image" : "default-icon";
+
+  const isEditable = !!onImageChange;
+  const isClickable = isEditable || !!onClick;
+
+  const handleClick = (e) => {
+    if (isEditable) {
+      fileInputRef.current?.click();
+    } else if (onClick) {
+      onClick(e);
+    }
+  };
+
+  const handleFileChange = (event) => {
+    const file = event.target.files?.[0];
+    if (!file || !onImageChange) return;
+
+    const fileReader = new FileReader();
+    fileReader.onload = ({ target }) => {
+      onImageChange(target?.result ?? null);
+    };
+    fileReader.readAsDataURL(file);
+    event.target.value = "";
+  };
 
   return (
     <div 
-      className={`profile-avatar ${onClick ? "clickable" : ""} ${className}`.trim()}
-      onClick={onClick}
+      className={`profile-avatar ${isClickable ? "clickable" : ""} ${isEditable ? "editable" : ""} ${className}`.trim()}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (isClickable && (e.key === "Enter" || e.key === " ")) {
+          e.preventDefault();
+          handleClick(e);
+        }
+      }}
       style={style}
-      role={onClick ? "button" : undefined}
-      tabIndex={onClick ? 0 : undefined}
+      role={isClickable ? "button" : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      aria-label={isEditable ? "프로필 이미지 변경" : alt}
     >
-      <img src={displaySrc} alt={alt} />
+      <img src={displaySrc} alt={alt} className={imageClass} />
+      {isEditable && (
+        <div className="profile-edit-badge">
+          <img src={imageIcon} alt="이미지 변경 아이콘" className="edit-icon" />
+        </div>
+      )}
+      {isEditable && (
+        <input
+          type="file"
+          accept="image/*"
+          ref={fileInputRef}
+          onChange={handleFileChange}
+          style={{ display: "none" }}
+        />
+      )}
     </div>
   );
 }

--- a/FE/src/components/ProfileModal/ProfileModal.css
+++ b/FE/src/components/ProfileModal/ProfileModal.css
@@ -154,6 +154,22 @@
 .profile-project-list {
   display: flex;
   flex-direction: column;
+  max-height: 126px;
+  overflow-y: auto;
+  padding-right: 5px;
+}
+
+.profile-project-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.profile-project-list::-webkit-scrollbar-thumb {
+  background: #d9d9d9;
+  border-radius: 4px;
+}
+
+.profile-project-list::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .profile-project-item {

--- a/FE/src/components/ProfileModal/ProfileModal.css
+++ b/FE/src/components/ProfileModal/ProfileModal.css
@@ -76,26 +76,6 @@
   gap: 14px;
 }
 
-.profile-avatar {
-  box-sizing: border-box;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  width: 54px;
-  height: 54px;
-
-  background: #f1f1f1;
-  border: 1px solid #ababab;
-  border-radius: 50%;
-}
-
-.profile-avatar img {
-  width: 24px;
-  height: 24px;
-}
-
 .profile-name {
   font-family: "Pretendard";
   font-weight: 700;
@@ -134,7 +114,7 @@
   flex-direction: column;
   gap: 10px;
 
-  margin-top: 22px;
+  margin-top: 20px;
   padding-top: 18px;
 
   border-top: 1px solid #d9d9d9;
@@ -267,25 +247,4 @@
   line-height: 15px;
 
   color: #000000;
-}
-
-.profile-popover-close-btn {
-  width: 100%;
-  height: 40px;
-  margin-top: 18px;
-
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-
-  background: #fe9a57;
-  color: #ffffff;
-
-  font-family: "Pretendard";
-  font-weight: 700;
-  font-size: 16px;
-}
-
-.profile-popover-close-btn:hover {
-  background: #f58b45;
 }

--- a/FE/src/components/ProfileModal/ProfileModal.css
+++ b/FE/src/components/ProfileModal/ProfileModal.css
@@ -38,6 +38,36 @@
   justify-content: space-between;
   align-items: center;
   gap: 16px;
+  padding-right: 16px;
+}
+
+.profile-close-x-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 30px;
+  height: 30px;
+  padding: 0;
+
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-radius: 30%;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.profile-close-x-btn:hover {
+  background-color: #f1f1f1;
+}
+
+.profile-close-x-btn img {
+  width: 24px;
+  height: 24px;
 }
 
 .profile-user-info {

--- a/FE/src/components/ProfileModal/ProfileModal.css
+++ b/FE/src/components/ProfileModal/ProfileModal.css
@@ -43,8 +43,8 @@
 
 .profile-close-x-btn {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 10px;
+  right: 10px;
 
   display: flex;
   justify-content: center;
@@ -247,4 +247,56 @@
   line-height: 15px;
 
   color: #000000;
+}
+
+@media (max-width: 768px) {
+  .profile-popover {
+    top: 64px;
+    left: 50%;
+    transform: translateX(-50%);
+    
+    width: calc(100vw - 32px);
+    max-width: 360px;
+    padding: 20px 16px;
+  }
+
+  .profile-popover::before {
+    display: none;
+  }
+
+  .profile-user-info {
+    gap: 10px;
+  }
+
+  .profile-name {
+    font-size: 16px;
+  }
+
+  .completed-task {
+    font-size: 24px;
+  }
+
+  .total-task {
+    font-size: 16px;
+  }
+
+  .project-title {
+    font-size: 14px;
+  }
+
+  .project-period {
+    font-size: 11px;
+  }
+
+  .project-status {
+    min-width: 46px;
+    font-size: 11px;
+    padding: 2px 8px;
+  }
+
+  .profile-close-x-btn {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+}
 }

--- a/FE/src/components/ProfileModal/ProfileModal.css
+++ b/FE/src/components/ProfileModal/ProfileModal.css
@@ -1,0 +1,245 @@
+.profile-popover-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+
+  background: transparent;
+}
+
+.profile-popover {
+  position: absolute;
+  top: 72px;
+  left: 24px;
+  z-index: 1000;
+
+  width: 360px;
+  padding: 24px;
+
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0px 4px 24px rgba(0, 0, 0, 0.14);
+}
+
+.profile-popover::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: 30px;
+
+  width: 16px;
+  height: 16px;
+
+  background: #ffffff;
+  transform: rotate(45deg);
+}
+
+.profile-popover-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.profile-user-info {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.profile-avatar {
+  box-sizing: border-box;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 54px;
+  height: 54px;
+
+  background: #f1f1f1;
+  border: 1px solid #ababab;
+  border-radius: 50%;
+}
+
+.profile-avatar img {
+  width: 24px;
+  height: 24px;
+}
+
+.profile-name {
+  font-family: "Pretendard";
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 22px;
+
+  color: #000000;
+}
+
+.profile-task-count {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+}
+
+.completed-task {
+  font-family: "Y SpotlightOTF";
+  font-weight: 400;
+  font-size: 28px;
+  line-height: 34px;
+
+  color: #ff6600;
+}
+
+.total-task {
+  font-family: "Pretendard";
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 24px;
+
+  color: #ababab;
+}
+
+.profile-project-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  margin-top: 22px;
+  padding-top: 18px;
+
+  border-top: 1px solid #d9d9d9;
+}
+
+.profile-section-title {
+  margin: 0;
+
+  font-family: "Pretendard";
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 20px;
+
+  color: #000000;
+}
+
+.profile-project-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.profile-project-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+
+  padding: 12px 0;
+
+  border-bottom: 1px solid #eeeeee;
+}
+
+.project-main-info {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.project-title {
+  font-family: "Pretendard";
+  font-weight: 500;
+  font-size: 15px;
+  line-height: 18px;
+
+  color: #000000;
+}
+
+.project-period {
+  font-family: "Pretendard";
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 15px;
+
+  color: #ababab;
+}
+
+.project-sub-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.project-status {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  min-width: 52px;
+  height: 22px;
+  padding: 2px 12px;
+
+  border-radius: 20px;
+
+  font-family: "Pretendard";
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 15px;
+}
+
+.project-status.active {
+  background: #ffebde;
+  color: #fe9a57;
+}
+
+.project-status.done {
+  background: #d9d9d9;
+  color: #ffffff;
+}
+
+.project-score {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 3px;
+
+  width: 42px;
+}
+
+.score-number {
+  font-family: "Y SpotlightOTF";
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 24px;
+
+  color: #fe9a57;
+}
+
+.score-text,
+.empty-score {
+  font-family: "Pretendard";
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 15px;
+
+  color: #000000;
+}
+
+.profile-popover-close-btn {
+  width: 100%;
+  height: 40px;
+  margin-top: 18px;
+
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+
+  background: #fe9a57;
+  color: #ffffff;
+
+  font-family: "Pretendard";
+  font-weight: 700;
+  font-size: 16px;
+}
+
+.profile-popover-close-btn:hover {
+  background: #f58b45;
+}

--- a/FE/src/components/ProfileModal/ProfileModal.jsx
+++ b/FE/src/components/ProfileModal/ProfileModal.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import "./ProfileModal.css";
 import profileIcon from "../../assets/icons/profileIcon.svg";
 import closeIcon from "../../assets/icons/closeIcon.svg";
+import ProfileAvatar from "../ProfileAvatar/ProfileAvatar";
 
 function ProfileModal({ isOpen, onClose, user }) {
   if (!isOpen) return null;
@@ -12,6 +13,24 @@ function ProfileModal({ isOpen, onClose, user }) {
       period: "2025 - 03 - 20 ~",
       status: "진행중",
       score: null,
+    },
+    {
+      title: "WAP 해커톤",
+      period: "2025 - 03 - 20 ~ 2025 - 07 - 20",
+      status: "완료",
+      score: "4.7",
+    },
+    {
+      title: "WAP 해커톤",
+      period: "2025 - 03 - 20 ~ 2025 - 07 - 20",
+      status: "완료",
+      score: "4.7",
+    },
+    {
+      title: "WAP 해커톤",
+      period: "2025 - 03 - 20 ~ 2025 - 07 - 20",
+      status: "완료",
+      score: "4.7",
     },
     {
       title: "WAP 해커톤",
@@ -32,9 +51,7 @@ function ProfileModal({ isOpen, onClose, user }) {
 
         <div className="profile-popover-header">
           <div className="profile-user-info">
-            <div className="profile-avatar">
-              <img src={user?.profileImage || profileIcon} alt="프로필 이미지" />
-            </div>
+            <ProfileAvatar src={user?.profileImage || profileIcon} alt="프로필 이미지" />
 
             <strong className="profile-name">{user?.name || "김아무개"}</strong>
           </div>

--- a/FE/src/components/ProfileModal/ProfileModal.jsx
+++ b/FE/src/components/ProfileModal/ProfileModal.jsx
@@ -1,0 +1,84 @@
+import React from "react";
+import "./ProfileModal.css";
+import profileIcon from "../../assets/icons/profileIcon.svg";
+
+function ProfileModal({ isOpen, onClose, user }) {
+  if (!isOpen) return null;
+
+  const projects = user?.projects ?? [
+    {
+      title: "동아리 프로젝트",
+      period: "2025 - 03 - 20 ~",
+      status: "진행중",
+      score: null,
+    },
+    {
+      title: "WAP 해커톤",
+      period: "2025 - 03 - 20 ~ 2025 - 07 - 20",
+      status: "완료",
+      score: "4.7",
+    },
+  ];
+
+  return (
+    <>
+      <div className="profile-popover-backdrop" onClick={onClose} />
+
+      <div className="profile-popover" onClick={(e) => e.stopPropagation()}>
+        <div className="profile-popover-header">
+          <div className="profile-user-info">
+            <div className="profile-avatar">
+              <img src={user?.profileImage || profileIcon} alt="프로필 이미지" />
+            </div>
+
+            <strong className="profile-name">{user?.name || "김아무개"}</strong>
+          </div>
+
+          <div className="profile-task-count">
+            <span className="completed-task">{user?.completedTaskCount ?? 3}</span>
+            <span className="total-task">/{user?.totalTaskCount ?? 4}</span>
+          </div>
+        </div>
+
+        <div className="profile-project-section">
+          <h3 className="profile-section-title">프로젝트 경험</h3>
+
+          <div className="profile-project-list">
+            {projects.map((project, index) => (
+              <div className="profile-project-item" key={index}>
+                <div className="project-main-info">
+                  <span className="project-title">{project.title}</span>
+                  <span className="project-period">{project.period}</span>
+                </div>
+
+                <div className="project-sub-info">
+                  <span
+                    className={`project-status ${
+                      project.status === "진행중" ? "active" : "done"
+                    }`}
+                  >
+                    {project.status}
+                  </span>
+
+                  <div className="project-score">
+                    {project.score ? (
+                      <>
+                        <span className="score-number">{project.score}</span>
+                        <span className="score-text">점</span>
+                      </>
+                    ) : (
+                      <span className="empty-score"></span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+      </div>
+    </>
+  );
+}
+
+export default ProfileModal;

--- a/FE/src/components/ProfileModal/ProfileModal.jsx
+++ b/FE/src/components/ProfileModal/ProfileModal.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import "./ProfileModal.css";
 import profileIcon from "../../assets/icons/profileIcon.svg";
+import closeIcon from "../../assets/icons/closeIcon.svg";
 
 function ProfileModal({ isOpen, onClose, user }) {
   if (!isOpen) return null;
@@ -25,6 +26,10 @@ function ProfileModal({ isOpen, onClose, user }) {
       <div className="profile-popover-backdrop" onClick={onClose} />
 
       <div className="profile-popover" onClick={(e) => e.stopPropagation()}>
+        <button className="profile-close-x-btn" onClick={onClose} aria-label="닫기">
+            <img src={closeIcon} alt="닫기 아이콘" />
+        </button>
+
         <div className="profile-popover-header">
           <div className="profile-user-info">
             <div className="profile-avatar">
@@ -75,9 +80,6 @@ function ProfileModal({ isOpen, onClose, user }) {
             ))}
           </div>
         </div>
-        <button type="button" className="profile-popover-close-btn" onClick={onClose}>
-          닫기
-        </button>
       </div>
     </>
   );

--- a/FE/src/components/ProfileModal/ProfileModal.jsx
+++ b/FE/src/components/ProfileModal/ProfileModal.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import "./ProfileModal.css";
-import profileIcon from "../../assets/icons/profileIcon.svg";
 import closeIcon from "../../assets/icons/closeIcon.svg";
 import ProfileAvatar from "../ProfileAvatar/ProfileAvatar";
 
@@ -51,7 +50,7 @@ function ProfileModal({ isOpen, onClose, user }) {
 
         <div className="profile-popover-header">
           <div className="profile-user-info">
-            <ProfileAvatar src={user?.profileImage || profileIcon} alt="프로필 이미지" />
+            <ProfileAvatar src={user?.profileImage} alt="프로필 이미지" />
 
             <strong className="profile-name">{user?.name || "김아무개"}</strong>
           </div>

--- a/FE/src/components/ProfileModal/ProfileModal.jsx
+++ b/FE/src/components/ProfileModal/ProfileModal.jsx
@@ -75,7 +75,9 @@ function ProfileModal({ isOpen, onClose, user }) {
             ))}
           </div>
         </div>
-
+        <button type="button" className="profile-popover-close-btn" onClick={onClose}>
+          닫기
+        </button>
       </div>
     </>
   );

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -6,7 +6,6 @@ import projectMenuIcon from '../../assets/projectMenuIcon.svg';
 import SummaryCard from './components/SummaryCard';
 import ProjectBox from '../../components/ProjectBox/ProjectBox';
 import moreIcon from '../../assets/moreIcon.svg';
-import ProfileModal from '../../components/ProfileModal/ProfileModal';
 
 // 임시 데이터
 const dummyDashboardData = {
@@ -35,7 +34,6 @@ function DashboardPage() {
 
   const [isLoading, setIsLoading] = useState(true);
   const [visibleStatusCount, setVisibleStatusCount] = useState(3);
-  const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
 
   const navigate = useNavigate();
 
@@ -81,14 +79,6 @@ function DashboardPage() {
     setVisibleStatusCount((prevCount) => prevCount + 3);
   };
 
-  const openProfileModal = () => {
-    setIsProfileModalOpen(true);
-  };
-
-  const closeProfileModal = () => {
-    setIsProfileModalOpen(false);
-  };
-
   if (isLoading) {
     return (
       <div className="dashboard-container">
@@ -100,9 +90,7 @@ function DashboardPage() {
 
   return (
     <div className="dashboard-container">
-      <h1 className="dashboard-title" onClick={openProfileModal}>
-        대시보드
-      </h1>
+      <h1 className="dashboard-title">대시보드</h1>
 
       <div className="dashboard-content">
         <div className="dashboard-summary-row">
@@ -163,11 +151,6 @@ function DashboardPage() {
           </div>
         </div>
       </div>
-
-      <ProfileModal
-        isOpen={isProfileModalOpen}
-        onClose={closeProfileModal}
-      />
     </div>
   );
 }

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -6,6 +6,7 @@ import projectMenuIcon from '../../assets/projectMenuIcon.svg';
 import SummaryCard from './components/SummaryCard';
 import ProjectBox from '../../components/ProjectBox/ProjectBox';
 import moreIcon from '../../assets/moreIcon.svg';
+import ProfileModal from '../../components/ProfileModal/ProfileModal';
 
 // 임시 데이터
 const dummyDashboardData = {
@@ -34,6 +35,8 @@ function DashboardPage() {
 
   const [isLoading, setIsLoading] = useState(true);
   const [visibleStatusCount, setVisibleStatusCount] = useState(3);
+  const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -78,6 +81,14 @@ function DashboardPage() {
     setVisibleStatusCount((prevCount) => prevCount + 3);
   };
 
+  const openProfileModal = () => {
+    setIsProfileModalOpen(true);
+  };
+
+  const closeProfileModal = () => {
+    setIsProfileModalOpen(false);
+  };
+
   if (isLoading) {
     return (
       <div className="dashboard-container">
@@ -89,7 +100,9 @@ function DashboardPage() {
 
   return (
     <div className="dashboard-container">
-      <h1 className="dashboard-title">대시보드</h1>
+      <h1 className="dashboard-title" onClick={openProfileModal}>
+        대시보드
+      </h1>
 
       <div className="dashboard-content">
         <div className="dashboard-summary-row">
@@ -129,18 +142,18 @@ function DashboardPage() {
             </div>
 
             {visibleStatusCount < dashboardData.projects.length ? (
-              <button 
-                className="more-btn" 
-                onClick={handleShowMoreStatus} 
+              <button
+                className="more-btn"
+                onClick={handleShowMoreStatus}
                 style={{ alignSelf: 'center', marginTop: '16px' }}
               >
                 더보기
                 <img src={moreIcon} alt="moreIcon" />
               </button>
             ) : dashboardData.projects.length > 3 ? (
-              <button 
-                className="more-btn" 
-                onClick={() => setVisibleStatusCount(3)} 
+              <button
+                className="more-btn"
+                onClick={() => setVisibleStatusCount(3)}
                 style={{ alignSelf: 'center', marginTop: '16px' }}
               >
                 접기
@@ -150,6 +163,11 @@ function DashboardPage() {
           </div>
         </div>
       </div>
+
+      <ProfileModal
+        isOpen={isProfileModalOpen}
+        onClose={closeProfileModal}
+      />
     </div>
   );
 }

--- a/FE/src/pages/DashboardPage/DashboardPage.jsx
+++ b/FE/src/pages/DashboardPage/DashboardPage.jsx
@@ -34,7 +34,6 @@ function DashboardPage() {
 
   const [isLoading, setIsLoading] = useState(true);
   const [visibleStatusCount, setVisibleStatusCount] = useState(3);
-
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -130,18 +129,18 @@ function DashboardPage() {
             </div>
 
             {visibleStatusCount < dashboardData.projects.length ? (
-              <button
-                className="more-btn"
-                onClick={handleShowMoreStatus}
+              <button 
+                className="more-btn" 
+                onClick={handleShowMoreStatus} 
                 style={{ alignSelf: 'center', marginTop: '16px' }}
               >
                 더보기
                 <img src={moreIcon} alt="moreIcon" />
               </button>
             ) : dashboardData.projects.length > 3 ? (
-              <button
-                className="more-btn"
-                onClick={() => setVisibleStatusCount(3)}
+              <button 
+                className="more-btn" 
+                onClick={() => setVisibleStatusCount(3)} 
                 style={{ alignSelf: 'center', marginTop: '16px' }}
               >
                 접기


### PR DESCRIPTION
## 📌 개요
프로필 팝업창 UI를 구현하고, 프로필 아바타를 재사용 가능한 공통 컴포넌트로 분리했습니다.

## ⚙️ 작업 내용
- 프로필 팝업창 UI 구현
- 반응형 구현
- ProfileAvatar 공통 컴포넌트 분리 및 적용
- 프로필 아바타 이미지 변경 기능 추가 및 수정 가능 표시 배지 추가

###  pc버전 프로필 팝업
<img width="600" alt="image" src="https://github.com/user-attachments/assets/3b0f72ad-b3e7-468e-99e6-6b0a51ec1876" />

### 모바일 버전(아이폰 XR)
<img width="500" alt="image" src="https://github.com/user-attachments/assets/2dfad4b9-7bb7-46d6-ab52-efc9c8ae0812" />

### 프로필 아바타 (기본 ==> 수정 가능)
<img width="135" alt="스크린샷 2026-05-17 193238" src="https://github.com/user-attachments/assets/4b35c465-5f0b-40ed-bb64-5abfbf00b5d0" />
==>
<img width="135" alt="스크린샷 2026-05-17 203603" src="https://github.com/user-attachments/assets/e5e7e0f0-e476-4f69-8ca4-3dd343f7d355" />

## 🎸 기타사항
아직 팝업창을 표시할 부분이 없기 때문에 프리뷰로 확인 불가능할 듯합니다. 첨부 사진으로 UI 확인 부탁드려요.
