### PR TITLE
[refactor] 헤더 - 아바타를 공통 컴포넌트로 교체

### DIFF
--- a/FE/src/components/Header/Header.css
+++ b/FE/src/components/Header/Header.css
@@ -98,21 +98,6 @@
   font-size: 16px;
 }
 
-.header-avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background-color: #FF6600;
-  color: #FFFFFF;
-  font-family: 'Pretendard', sans-serif;
-  font-size: 14px;
-  font-weight: 700;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-
 @media (max-width: 768px) {
   .hamburger-btn {
     display: flex;

--- a/FE/src/components/Header/Header.jsx
+++ b/FE/src/components/Header/Header.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { getUserInfo } from '../../api/userProfileApi.js';
 import logoImg from '../../assets/logoOrange.svg';
+import ProfileAvatar from '../ProfileAvatar/ProfileAvatar';
 import './Header.css';
 
 function Header({ onMenuClick }) {
@@ -44,7 +45,7 @@ function Header({ onMenuClick }) {
           <strong>{userData.userName}</strong> 님 안녕하세요 :)
         </Link>
         <Link to="/profile">
-          <div className="header-avatar">{userData.userInitial}</div>
+          <ProfileAvatar size="36px" />
         </Link>
       </div>
     </header>

--- a/FE/src/components/ProfileAvatar/ProfileAvatar.css
+++ b/FE/src/components/ProfileAvatar/ProfileAvatar.css
@@ -19,8 +19,8 @@
 }
 
 .profile-avatar .default-icon {
-  width: 24px;
-  height: 24px;
+  width: 44.5%;
+  height: 44.5%;
   object-fit: contain;
 }
 

--- a/FE/src/components/ProfileAvatar/ProfileAvatar.jsx
+++ b/FE/src/components/ProfileAvatar/ProfileAvatar.jsx
@@ -3,7 +3,7 @@ import "./ProfileAvatar.css";
 import profileIcon from "../../assets/icons/profileIcon.svg";
 import imageIcon from "../../assets/icons/imageIcon.svg";
 
-function ProfileAvatar({ src, alt = "프로필 이미지", className = "", onClick, style, onImageChange }) {
+function ProfileAvatar({ src, alt = "프로필 이미지", className = "", onClick, style, onImageChange, size }) {
   const fileInputRef = useRef(null);
   const displaySrc = src || profileIcon;
   const imageClass = src ? "user-image" : "default-icon";
@@ -41,7 +41,7 @@ function ProfileAvatar({ src, alt = "프로필 이미지", className = "", onCli
           handleClick(e);
         }
       }}
-      style={style}
+      style={{ width: size, height: size, ...style }}
       role={isClickable ? "button" : undefined}
       tabIndex={isClickable ? 0 : undefined}
       aria-label={isEditable ? "프로필 이미지 변경" : alt}


### PR DESCRIPTION
## 📌 개요
헤더에 직접 구현되어 있던 아바타를 공통 컴포넌트 ProfileAvatar로 교체했습니다.

## ⚙️ 작업 내용
- ProfileAvatar에 사이즈 조절을 위한 props 추가
- Header의 기존 아바타 코드 제거 및 공통 컴포넌트 ProfileAvatar로 변경
<img width="400" alt="image" src="https://github.com/user-attachments/assets/365c7c0a-5337-40e2-8eff-0f5bc10358e8" />

 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
