### PR TITLE
[feat] 대시보드 조회 API 구현

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/dashboard/controller/DashboardController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/dashboard/controller/DashboardController.java
@@ -1,4 +1,71 @@
 package org.example.promate.domain.dashboard.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.dashboard.code.DashboardSuccessCode;
+import org.example.promate.domain.dashboard.dto.DashboardResponseDTO;
+import org.example.promate.domain.dashboard.service.DashboardService;
+import org.example.promate.global.ApiPayload.ApiResponse;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/dashboard")
 public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    @GetMapping("/projects/me")
+    public ApiResponse<List<DashboardResponseDTO.MyProjectDTO>> getMyProjects(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.onSuccess(
+                DashboardSuccessCode.GET_ACTIVE_PROJECTS_SUCCESS,
+                dashboardService.getMyProjects(userId)
+        );
+    }
+
+    @GetMapping("/tasks/deadline")
+    public ApiResponse<List<DashboardResponseDTO.TaskDTO>> getDeadlineTasks(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.onSuccess(
+                DashboardSuccessCode.GET_DEADLINE_TASKS_SUCCESS,
+                dashboardService.getDeadlineTasks(userId)
+        );
+    }
+
+    @GetMapping("/tasks/completed")
+    public ApiResponse<List<DashboardResponseDTO.TaskDTO>> getCompletedTasks(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.onSuccess(
+                DashboardSuccessCode.GET_COMPLETED_TASKS_SUCCESS,
+                dashboardService.getCompletedTasks(userId)
+        );
+    }
+
+    @GetMapping("/calendar")
+    public ApiResponse<List<DashboardResponseDTO.CalendarDTO>> getCalendar(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.onSuccess(
+                DashboardSuccessCode.GET_CALENDAR_SUCCESS,
+                dashboardService.getCalendar(userId)
+        );
+    }
+
+    @GetMapping("/projects/status")
+    public ApiResponse<List<DashboardResponseDTO.ProjectStatusDTO>> getProjectStatus(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.onSuccess(
+                DashboardSuccessCode.GET_PROJECT_STATUS_SUCCESS,
+                dashboardService.getProjectStatus(userId)
+        );
+    }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/dashboard/dto/DashboardResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/dashboard/dto/DashboardResponseDTO.java
@@ -1,0 +1,52 @@
+package org.example.promate.domain.dashboard.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class DashboardResponseDTO {
+
+    @Getter
+    @Builder
+    public static class MyProjectDTO {
+        private Long projectId;
+        private String title;
+        private LocalDate endDate;
+        private String dueStatus; // 프로젝트 마감일 기준 상태(임박, 여유)
+    }
+
+    @Getter
+    @Builder
+    public static class TaskDTO {
+        private Long taskId;
+        private Long projectId;
+        private String projectTitle;
+        private String title;
+        private LocalDate dueDate;
+    }
+
+    @Getter
+    @Builder
+    public static class CalendarDTO {
+        private Long scheduleId;
+        private Long projectId;
+        private String projectTitle;
+        private String title;
+        private String content;
+        private LocalDate startAt;
+        private LocalDate endAt;
+    }
+
+    @Getter
+    @Builder
+    public static class ProjectStatusDTO {
+        private Long projectId;
+        private String title;
+        private LocalDate endDate;
+        private String dueStatus; // 프로젝트 마감일 기준 상태(임박, 여유)
+        private Long completedTaskCount;
+        private Long totalTaskCount;
+        private Integer progressRate;
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/dashboard/service/DashboardService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/dashboard/service/DashboardService.java
@@ -1,4 +1,149 @@
 package org.example.promate.domain.dashboard.service;
 
+import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.dashboard.dto.DashboardResponseDTO;
+import org.example.promate.domain.project.entity.Project;
+import org.example.promate.domain.project.enums.ProjectStatus;
+import org.example.promate.domain.project.repository.MemberRepository;
+import org.example.promate.domain.workspace.entity.Task;
+import org.example.promate.domain.workspace.enums.TaskStatus;
+import org.example.promate.domain.workspace.repository.ScheduleRepository;
+import org.example.promate.domain.workspace.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DashboardService {
+
+    private final MemberRepository memberRepository;
+    private final TaskRepository taskRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    public List<DashboardResponseDTO.MyProjectDTO> getMyProjects(Long userId) {
+        return memberRepository.findByUserIdAndProjectStatus(userId, ProjectStatus.ACTIVE)
+                .stream()
+                .map(member -> {
+                    Project project = member.getProject();
+
+                    return DashboardResponseDTO.MyProjectDTO.builder()
+                            .projectId(project.getId())
+                            .title(project.getTitle())
+                            .endDate(project.getEndDate())
+                            .dueStatus(getDueStatus(project.getEndDate()))
+                            .build();
+                })
+                .toList();
+    }
+
+    public List<DashboardResponseDTO.TaskDTO> getDeadlineTasks(Long userId) {
+        LocalDate now = LocalDate.now();
+        LocalDate sevenDaysLater = now.plusDays(7);
+
+        return taskRepository
+                .findByMemberUserIdAndDueDateBetweenAndIsDeletedFalse(
+                        userId,
+                        now,
+                        sevenDaysLater
+                )
+                .stream()
+                .map(this::toTaskDTO)
+                .toList();
+        }
+
+    public List<DashboardResponseDTO.TaskDTO> getCompletedTasks(Long userId) {
+        return taskRepository
+                .findByMemberUserIdAndStatusAndIsDeletedFalse(
+                        userId,
+                        TaskStatus.DONE
+                )
+                .stream()
+                .map(this::toTaskDTO)
+                .toList();
+    }
+
+    public List<DashboardResponseDTO.CalendarDTO> getCalendar(Long userId) {
+        List<Long> projectIds = memberRepository.findByUserIdAndProjectStatus(userId, ProjectStatus.ACTIVE)
+                .stream()
+                .map(member -> member.getProject().getId())
+                .toList();
+
+        if (projectIds.isEmpty()) {
+            return List.of();
+        }
+
+        return scheduleRepository.findByProjectIdInAndIsDeletedFalse(projectIds)
+                .stream()
+                .map(schedule -> DashboardResponseDTO.CalendarDTO.builder()
+                        .scheduleId(schedule.getId())
+                        .projectId(schedule.getProject().getId())
+                        .projectTitle(schedule.getProject().getTitle())
+                        .title(schedule.getTitle())
+                        .content(schedule.getContent())
+                        .startAt(schedule.getStartAt())
+                        .endAt(schedule.getEndAt())
+                        .build())
+                .toList();
+    }
+
+    public List<DashboardResponseDTO.ProjectStatusDTO> getProjectStatus(Long userId) {
+        return memberRepository.findByUserIdAndProjectStatus(userId, ProjectStatus.ACTIVE)
+                .stream()
+                .map(member -> {
+                    Project project = member.getProject();
+
+                    Long totalTaskCount = (long) taskRepository.countAllByProjectIdAndIsDeletedFalse(project.getId());
+
+                    Long completedTaskCount = (long) taskRepository.countAllByProjectIdAndStatusAndIsDeletedFalse(
+                            project.getId(),
+                            TaskStatus.DONE
+                    );
+
+                    // 완료된 태스크 비율 기준 진행률 계산(%), 전체 태스크 수가 0이면 그냥 0 반환
+                    int progressRate = totalTaskCount == 0
+                            ? 0
+                            : (int) Math.round((double) completedTaskCount / totalTaskCount * 100);
+
+                    return DashboardResponseDTO.ProjectStatusDTO.builder()
+                            .projectId(project.getId())
+                            .title(project.getTitle())
+                            .endDate(project.getEndDate())
+                            .dueStatus(getDueStatus(project.getEndDate()))
+                            .completedTaskCount(completedTaskCount)
+                            .totalTaskCount(totalTaskCount)
+                            .progressRate(progressRate)
+                            .build();
+                })
+                .toList();
+    }
+
+    private DashboardResponseDTO.TaskDTO toTaskDTO(Task task) {
+        return DashboardResponseDTO.TaskDTO.builder()
+                .taskId(task.getId())
+                .projectId(task.getProject().getId())
+                .projectTitle(task.getProject().getTitle())
+                .title(task.getTitle())
+                .dueDate(task.getDueDate())
+                .build();
+    }
+
+    // 마감일까지 남은 일수를 기준으로 상태 반환(7일 이하-임박, 그 외-여유)
+    private String getDueStatus(LocalDate dueDate) {
+        if (dueDate == null) {
+            return "여유";
+        }
+
+        long daysLeft = ChronoUnit.DAYS.between(LocalDate.now(), dueDate);
+
+        if (daysLeft <= 7) {
+            return "임박";
+        }
+
+        return "여유";
+    }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/ScheduleRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/ScheduleRepository.java
@@ -30,4 +30,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     Optional<Schedule> findByIdAndIsDeletedFalse(Long id);
 
+    List<Schedule> findByProjectIdInAndIsDeletedFalse(List<Long> projectIds); // dashboard에서 사용
+
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,4 +28,17 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     
     int countByProjectIdAndStatus(Long projectId, TaskStatus status);
     int countByProjectIdAndStatusIn(Long projectId, List<TaskStatus> statuses); // 완료, 미완료 task 조회
+
+
+    // dashboard에서 사용
+    List<Task> findByMemberUserIdAndDueDateBetweenAndIsDeletedFalse(
+            Long userId,
+            LocalDate startDate,
+            LocalDate endDate
+    );
+
+    List<Task> findByMemberUserIdAndStatusAndIsDeletedFalse(
+            Long userId,
+            TaskStatus status
+    );
 }


### PR DESCRIPTION
## 📌 개요
대시보드 페이지에 들어갈 조회 API들을 구현하였습니다.

## ⚙️ 작업 내용
- 참여 중인 프로젝트 목록 조회
- 마감 임박 테스크 조회
- 완료 테스크 조회
- 캘린더 표시 일정 조회
- 프로젝트 현황 조회
 
## 🎸 기타사항
- dueStatus는 프로젝트 종료일(endDate) 기준으로 계산됩니다.
- 종료일까지 남은 일수가 7일 이하인 경우 '임박', 그 외는 '여유'를 반환합니다.
- 기존에 설정한 종료일이 이미 지났어도 프로젝트 상태가 ACTIVE라면 '임박'으로 표시됩니다.
- 프로젝트 현황 조회 중 완료 테스크/전체 테스크를 통해 퍼센트를 표시할 때, 전체 테스크 개수가 0개라면 0%로 반환합니다.
