### PR TITLE
[feat] 프로젝트 팀원 목록 조회 API 구현

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/project/code/MemberErrorCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/code/MemberErrorCode.java
@@ -11,6 +11,7 @@ public enum MemberErrorCode implements BaseErrorCode {
     SCHEDULE_FORBIDDEN_NOT_PROJECT_MEMBER(HttpStatus.FORBIDDEN, "MEMBER_E001", "해당 프로젝트에 속한 사용자만 수행 가능합니다."),
     TASK_FORBIDDEN_NOT_PROJECT_MEMBER(HttpStatus.FORBIDDEN, "MEMBER_E002", "해당 프로젝트에 속한 사용자만 수행 가능합니다."),
     POST_FORBIDDEN_NOT_PROJECT_MEMBER(HttpStatus.FORBIDDEN, "MEMBER_E003", "해당 프로젝트에 속한 사용자만 수행 가능합니다."),
+    MEMBER_FORBIDDEN_NOT_PROJECT_MEMBER(HttpStatus.FORBIDDEN, "MEMBER_E004", "해당 프로젝트에 속한 사용자만 수행 가능합니다."),
     ;
 
 

--- a/BE/promate/src/main/java/org/example/promate/domain/project/code/ProjectSuccessCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/code/ProjectSuccessCode.java
@@ -1,0 +1,20 @@
+package org.example.promate.domain.project.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.promate.global.ApiPayload.code.BaseSuccessCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ProjectSuccessCode implements BaseSuccessCode {
+
+    MY_PROJECTS_FOUND(HttpStatus.OK, "PROJECT_S001", "내 프로젝트 목록 조회에 성공했습니다."),
+    MY_APPLICATIONS_FOUND(HttpStatus.OK, "PROJECT_S002", "내 지원 현황 조회에 성공했습니다."),
+    MY_ACTIVITIES_FOUND(HttpStatus.OK, "PROJECT_S003", "내 활동 이력 조회에 성공했습니다."),
+    PROJECT_MEMBER_FOUND(HttpStatus.OK, "PROJECT_S004", "팀원 목록 조회에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/project/controller/ProjectController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/controller/ProjectController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.promate.domain.project.dto.MyActivityResponseDTO;
 import org.example.promate.domain.project.dto.MyApplicationResponseDTO;
 import org.example.promate.domain.project.dto.MyProjectResponseDTO;
+import org.example.promate.domain.project.dto.ProjectMemberResponseDTO;
 import org.example.promate.domain.project.service.ProjectService;
 import org.example.promate.global.ApiPayload.ApiResponse;
 import org.example.promate.global.ApiPayload.code.GeneralSuccessCode;
@@ -48,6 +49,17 @@ public class ProjectController {
         return ApiResponse.onSuccess(
                 GeneralSuccessCode.OK,
                 projectService.getMyActivities(userId)
+        );
+    }
+
+    @GetMapping("/{projectId}/members")
+    public ApiResponse<List<ProjectMemberResponseDTO>> getProjectMembers(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long projectId
+    ) {
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                projectService.getProjectMembers(userId, projectId)
         );
     }
 

--- a/BE/promate/src/main/java/org/example/promate/domain/project/controller/ProjectController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/controller/ProjectController.java
@@ -2,13 +2,13 @@ package org.example.promate.domain.project.controller;
 
 import lombok.RequiredArgsConstructor;
 
+import org.example.promate.domain.project.code.ProjectSuccessCode;
 import org.example.promate.domain.project.dto.MyActivityResponseDTO;
 import org.example.promate.domain.project.dto.MyApplicationResponseDTO;
 import org.example.promate.domain.project.dto.MyProjectResponseDTO;
 import org.example.promate.domain.project.dto.ProjectMemberResponseDTO;
 import org.example.promate.domain.project.service.ProjectService;
 import org.example.promate.global.ApiPayload.ApiResponse;
-import org.example.promate.global.ApiPayload.code.GeneralSuccessCode;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,7 +27,7 @@ public class ProjectController {
             @AuthenticationPrincipal Long userId
     ) {
         return ApiResponse.onSuccess(
-                GeneralSuccessCode.OK,
+                ProjectSuccessCode.MY_PROJECTS_FOUND,
                 projectService.getMyProjects(userId)
         );
     }
@@ -37,7 +37,7 @@ public class ProjectController {
             @AuthenticationPrincipal Long userId
     ) {
         return ApiResponse.onSuccess(
-                GeneralSuccessCode.OK,
+                ProjectSuccessCode.MY_APPLICATIONS_FOUND,
                 projectService.getMyApplications(userId)
         );
     }
@@ -47,7 +47,7 @@ public class ProjectController {
             @AuthenticationPrincipal Long userId
     ) {
         return ApiResponse.onSuccess(
-                GeneralSuccessCode.OK,
+                ProjectSuccessCode.MY_ACTIVITIES_FOUND,
                 projectService.getMyActivities(userId)
         );
     }
@@ -58,7 +58,7 @@ public class ProjectController {
             @PathVariable Long projectId
     ) {
         return ApiResponse.onSuccess(
-                GeneralSuccessCode.OK,
+                ProjectSuccessCode.PROJECT_MEMBER_FOUND,
                 projectService.getProjectMembers(userId, projectId)
         );
     }

--- a/BE/promate/src/main/java/org/example/promate/domain/project/dto/ProjectMemberResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/dto/ProjectMemberResponseDTO.java
@@ -1,0 +1,16 @@
+package org.example.promate.domain.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProjectMemberResponseDTO {
+
+    private Long userId;
+    private String name;
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/project/repository/MemberRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/repository/MemberRepository.java
@@ -32,4 +32,8 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     );
 
     Optional<Member> findByUserId(Long userId);
+
+    List<Member> findAllByProjectIdAndIsDeletedFalse(Long projectId);
+
+    boolean existsByProjectIdAndUserIdAndIsDeletedFalse(Long projectId, Long userId);
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/project/service/ProjectService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/service/ProjectService.java
@@ -2,11 +2,16 @@ package org.example.promate.domain.project.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.promate.domain.apply.repository.ApplyRepository;
+import org.example.promate.domain.project.code.MemberErrorCode;
+import org.example.promate.domain.project.code.ProjectErrorCode;
 import org.example.promate.domain.project.dto.MyActivityResponseDTO;
 import org.example.promate.domain.project.dto.MyApplicationResponseDTO;
 import org.example.promate.domain.project.dto.MyProjectResponseDTO;
+import org.example.promate.domain.project.dto.ProjectMemberResponseDTO;
 import org.example.promate.domain.project.entity.Project;
 import org.example.promate.domain.project.enums.ProjectStatus;
+import org.example.promate.domain.project.exception.MemberException;
+import org.example.promate.domain.project.exception.ProjectException;
 import org.example.promate.domain.project.repository.MemberRepository;
 import org.example.promate.domain.project.repository.ProjectRepository;
 import org.example.promate.domain.recruit.repository.RecruitRepository;
@@ -122,6 +127,33 @@ public class ProjectService {
                             .averageReviewScore(averageReviewScore)
                             .build();
                 })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectMemberResponseDTO> getProjectMembers(
+            Long userId,
+            Long projectId
+    ) {
+        projectRepository.findById(projectId)
+                .orElseThrow(() -> new ProjectException(ProjectErrorCode.ID_NOT_FOUND));
+
+        boolean isProjectMember =
+                memberRepository.existsByProjectIdAndUserIdAndIsDeletedFalse(
+                        projectId,
+                        userId
+                );
+
+        if (!isProjectMember) {
+            throw new MemberException(MemberErrorCode.MEMBER_FORBIDDEN_NOT_PROJECT_MEMBER);
+        }
+
+        return memberRepository.findAllByProjectIdAndIsDeletedFalse(projectId)
+                .stream()
+                .map(member -> ProjectMemberResponseDTO.builder()
+                        .userId(member.getUser().getId())
+                        .name(member.getUser().getName())
+                        .build())
                 .toList();
     }
 }


### PR DESCRIPTION
## 📌 개요
프로젝트 대시보드 페이지의 프로젝트 팀원 목록 조회 API를 구현하였습니다.

## ⚙️ 작업 내용
- 프로젝트 팀원 목록 조회 API
 
## 🎸 기타사항
팀원 역할 부분은 표시하지 않는 것으로 하였습니다. 팀원의 user id와 이름만을 반환합니다.