### PR TITLE
[feat] 프로젝트 조회 응답에 설명 및 모집인원 필드 추가

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/project/dto/MyActivityResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/dto/MyActivityResponseDTO.java
@@ -9,4 +9,5 @@ public class MyActivityResponseDTO {
     private Long projectId;
     private String title;
     private Double averageReviewScore;
+    private String description; // 프로젝트 설명
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/project/dto/MyApplicationResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/dto/MyApplicationResponseDTO.java
@@ -14,4 +14,6 @@ public class MyApplicationResponseDTO {
     private String title;
     private Status status;
     private LocalDateTime createdAt;
+    private String description; // 프로젝트 설명
+    private Integer recruitCount; // 모집인원 반환
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/project/dto/MyProjectResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/dto/MyProjectResponseDTO.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 import org.example.promate.domain.project.enums.ProjectStatus;
 
+import java.time.LocalDate;
+
 @Getter
 @Builder
 public class MyProjectResponseDTO {
@@ -11,6 +13,8 @@ public class MyProjectResponseDTO {
     private Long projectId;
     private String title;
     private ProjectStatus projectStatus;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private int completedTaskCount;
     private int incompleteTaskCount;
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/project/service/ProjectService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/service/ProjectService.java
@@ -47,6 +47,8 @@ public class ProjectService {
                         .applicationId(apply.getId())
                         .recruitmentId(apply.getRecruit().getId())
                         .title(apply.getRecruit().getTitle())
+                        .description(apply.getRecruit().getDescription())
+                        .recruitCount(apply.getRecruit().getTotalSlots())
                         .status(apply.getStatus())
                         .createdAt(apply.getCreatedAt())
                         .build())
@@ -124,6 +126,7 @@ public class ProjectService {
                     return MyActivityResponseDTO.builder()
                             .projectId(member.getProject().getId())
                             .title(member.getProject().getTitle())
+                            .description(member.getProject().getDescription())
                             .averageReviewScore(averageReviewScore)
                             .build();
                 })

--- a/BE/promate/src/main/java/org/example/promate/domain/project/service/ProjectService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/service/ProjectService.java
@@ -81,6 +81,8 @@ public class ProjectService {
                             .projectId(project.getId())
                             .title(project.getTitle())
                             .projectStatus(project.getStatus())
+                            .startDate(project.getStartDate())
+                            .endDate(project.getEndDate())
                             .completedTaskCount(completedTaskCount)
                             .incompleteTaskCount(incompleteTaskCount)
                             .build();


### PR DESCRIPTION
## 📌 개요
프로젝트 조회 api의 응답에 프로젝트 설명과 모집인원을 추가하였습니다.

## ⚙️ 작업 내용
- 내 지원 현황 조회 api 응답에 프로젝트 설명, 모집인원 추가
- 완료된 프로젝트 조회 api 응답에 프로젝트 설명 추가
 
## 🎸 기타사항
추가적으로 진행 중 프로젝트 조회 api 응답에 프로젝트 시작일과 마감일을 추가하였습니다.
