### PR TITLE
[feat/refactor] 모집글 & 프로젝트 마감 자동화 및 지원 상태별 조회 권한 제어 

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/apply/service/ApplyService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/service/ApplyService.java
@@ -14,6 +14,7 @@ import org.example.promate.domain.project.repository.ProjectRepository;
 import org.example.promate.domain.recruit.entity.Recruit;
 import org.example.promate.domain.recruit.enums.RecruitStatus;
 import org.example.promate.domain.recruit.repository.RecruitRepository;
+import org.example.promate.domain.recruit.service.RecruitService;
 import org.example.promate.domain.review.repository.MemberReviewRepository;
 import org.example.promate.domain.user.entity.User;
 import org.example.promate.domain.user.entity.UserProjectHistory;
@@ -47,6 +48,7 @@ public class ApplyService {
     private final TaskRepository taskRepository;
     private final UserProjectHistoryRepository userProjectHistoryRepository;
     private final MemberReviewRepository memberReviewRepository;
+    private final RecruitService recruitService;
 
 
     public ApplyFormResponse getApplyForm(Long recruitmentId, Long userId) {
@@ -316,6 +318,14 @@ public class ApplyService {
         // 바꾸려는 상태에 따른 비즈니스 로직 분기
         if (targetStatus == Status.ACCEPTED) {
             handleAccept(recruit, apply);
+            //  수락 처리 직후, 현재 프로젝트에 채워진 멤버 수 확인
+            int currentMemberCount = memberRepository.countByProjectId(recruit.getProject().getId());
+            int maxMemberCount = recruit.getTotalSlots();
+
+            // 목표 인원이 다 찼다면 자동으로 모집글 마감 및 프로젝트 ACTIVE 전환 프로세스 실행
+            if (currentMemberCount >= maxMemberCount) {
+                recruitService.processCompletion(recruit);
+            }
         } else if (targetStatus == Status.REJECTED) {
             handleReject(recruit, apply, currentStatus);
         }

--- a/BE/promate/src/main/java/org/example/promate/domain/project/entity/Project.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/entity/Project.java
@@ -69,6 +69,8 @@ public class Project extends BaseTimeEntity {
         this.status = status;
     }
 
+    public void updateStartDate(LocalDate date){this.startDate = date;}
+
     public void disconnectRecruit() {
         if (this.recruit != null) {
             // 1. 반대편(Recruit) 객체의 참조를 먼저 제거

--- a/BE/promate/src/main/java/org/example/promate/domain/project/repository/MemberRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/repository/MemberRepository.java
@@ -36,4 +36,6 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     List<Member> findAllByProjectIdAndIsDeletedFalse(Long projectId);
 
     boolean existsByProjectIdAndUserIdAndIsDeletedFalse(Long projectId, Long userId);
+
+    int countByProjectId(Long projectId);
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/project/repository/ProjectRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/repository/ProjectRepository.java
@@ -1,11 +1,16 @@
 package org.example.promate.domain.project.repository;
 
 import org.example.promate.domain.project.entity.Project;
+import org.example.promate.domain.project.enums.ProjectStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectRepositoryCustom {
     Optional<Project> findById(Long id);
+
+    List<Project> findAllByStatusAndEndDateLessThanEqual(ProjectStatus status, LocalDate date);
 }
 

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/code/RecruitSuccessCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/code/RecruitSuccessCode.java
@@ -28,7 +28,7 @@ public enum RecruitSuccessCode implements BaseSuccessCode {
     APPLY_DETAIL_FETCHED(HttpStatus.OK, "RECRUIT_S015", "팀 지원서 상세 조회를 성공했습니다."),
     APPLY_STATUS_UPDATED(HttpStatus.OK, "RECRUIT_S016", "지원서 상태 수정을 완료되었습니다."),
 
-    RECRUITMENT_COMPLETED(HttpStatus.NO_CONTENT,"RECRUIT_S0017", "모집 종료 상태로 변경 완료했습니다.")
+    RECRUITMENT_COMPLETED(HttpStatus.NO_CONTENT,"RECRUIT_S0017", "모집이 완료되었으며, 프로젝트 팀이 생성되었습니다.")
     ;
 
     private final HttpStatus status;

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/request/RecruitCreateRequest.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/request/RecruitCreateRequest.java
@@ -15,5 +15,5 @@ public record RecruitCreateRequest(
         Category category,
         @Min(value = 1, message = "최소 1명 이상이어야 합니다")
         int totalSlots,
-        LocalDateTime deadline
+        LocalDateTime endDate
 ){}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitResponse.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 public record RecruitResponse(
         Long recruitmentId,
         String title,
+        String description,     // 추가 <- 북마크된 모집글용
         Category category,
         LocalDateTime createdAt,
         LocalDateTime deadline,
@@ -20,10 +21,24 @@ public record RecruitResponse(
         Status myApplyStatus,   // 본인의 지원 상태 (PENDING, ACCEPTED, REJECTED / 지원 안 했으면 null)
         Long myApplicationId    // 본인의 지원서 ID (지원 안 했으면 null)
 ) {
-    public static RecruitResponse of(Recruit recruit, Status myApplyStatus, Long myApplicationId) {
+    public static RecruitResponse of(Recruit recruit, Status myApplyStatus, Long myApplicationId, Long userId) {
+
+        Long targetProjectId = null;
+
+        // 1. 현재 유저가 이 모집글을 쓴 팀장(Leader)이거나
+        // 2. 지원 상태가 최종 수락(ACCEPTED)된 합격자인 경우
+        boolean isLeader = recruit.getUser() != null && recruit.getUser().getId().equals(userId);
+        boolean isAccepted = (myApplyStatus == Status.ACCEPTED);
+
+        // 둘 중 하나라도 해당하고, 프로젝트가 존재할 때만 ID를 열어줍니다.
+        if ((isLeader || isAccepted) && recruit.getProject() != null) {
+            targetProjectId = recruit.getProject().getId();
+        }
+
         return new RecruitResponse(
                 recruit.getId(),
                 recruit.getTitle(),
+                recruit.getDescription(),
                 recruit.getCategory(),
                 recruit.getCreatedAt(),
                 recruit.getDeadline(),
@@ -31,7 +46,7 @@ public record RecruitResponse(
                 recruit.getTotalSlots(),
                 recruit.getJoinedCount(),
                 // Project 엔티티 연관관계가 있다면 ID 추출, 없으면 null
-                recruit.getProject() != null ? recruit.getProject().getId() : null,
+                targetProjectId,
                 myApplyStatus,
                 myApplicationId
         );

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepository.java
@@ -1,12 +1,16 @@
 package org.example.promate.domain.recruit.repository;
 
 import org.example.promate.domain.recruit.entity.Recruit;
+import org.example.promate.domain.recruit.enums.RecruitStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface RecruitRepository extends JpaRepository<Recruit, Long>, RecruitRepositoryCustom {
     Optional<Recruit> findByIdAndIsDeletedFalse(Long id);
+    List<Recruit> findAllByStatusAndDeadlineBefore(RecruitStatus status, LocalDateTime time);
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
@@ -30,6 +30,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -55,7 +57,7 @@ public class RecruitService {
                 .description(request.description())
                 .category(request.category())
                 .totalSlots(request.totalSlots())
-                .deadline(request.deadline())
+                .deadline(LocalDateTime.now().plusDays(7)) //모집 기한 일주일 고정
                 .user(writer)
                 .build();
 
@@ -64,6 +66,7 @@ public class RecruitService {
                 .title(request.title()) // 일단 모집글 제목을 프로젝트명으로 사용
                 .description(request.description())
                 .status(ProjectStatus.PREPARING) // 아직 시작 전 상태
+                .endDate(request.endDate().toLocalDate())
                 .recruit(recruit)
                 .user(writer)
                 .build();
@@ -181,15 +184,16 @@ public class RecruitService {
         return new RecruitStatusResponse(null, recruit.getStatus());
     }
 
-    private RecruitStatusResponse processCompletion(Recruit recruit) {
+    public RecruitStatusResponse processCompletion(Recruit recruit) {
         // 임시 프로젝트 상태 변경 (PREPARING -> ACTIVE)
         Project project = recruit.getProject();
         if (project == null) {
             throw new GeneralException(RecruitErrorCode.PROJECT_NOT_FOUND);
         }
+        project.updateStartDate(LocalDate.now());
         project.updateStatus(ProjectStatus.ACTIVE);
 
-        // 모집글 + 지원서 데이터 청소 (일단 Hard Delete를 채택함) <- 추후 개발 진도에 따라 수정 고려
+        /* 모집글 + 지원서 데이터 청소 (일단 Hard Delete를 채택함) <- 추후 개발 진도에 따라 수정 고려
         // 두 객체 간 매핑 관계 부터 해제하기
         project.disconnectRecruit();
 
@@ -197,7 +201,7 @@ public class RecruitService {
         applyRepository.deleteAllByRecruitId(recruit.getId());
 
         // 모집글 삭제
-        recruitRepository.delete(recruit);
+        recruitRepository.delete(recruit);*/
 
         return new RecruitStatusResponse(project.getId(), RecruitStatus.COMPLETED);
     }
@@ -268,8 +272,25 @@ public class RecruitService {
             return RecruitResponse.of(
                     recruit,
                     myApply != null ? myApply.getStatus() : null,
-                    myApply != null ? myApply.getId() : null
+                    myApply != null ? myApply.getId() : null,
+                    userId
             );
         }).toList();
+    }
+
+    //모집글 만료 로직
+    public void processExpiration(Recruit recruit) {
+
+        recruit.updateStatus(RecruitStatus.EXPIRED);
+
+        // 임시 프로젝트 데이터 청소 (Hard Delete)
+        // 팀 빌딩에 실패했으므로 가동되지 못한 임시 프로젝트와 팀장 멤버 데이터는 제거
+        Project project = recruit.getProject();
+        if (project != null) {
+            recruit.disconnectProject();
+            projectRepository.delete(project);
+        }
+        //지원서 청소
+        applyRepository.deleteAllByRecruitId(recruit.getId());
     }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
@@ -26,8 +26,6 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             "and t.isDeleted = false")
     Optional<Task> findByIdAndIsDeletedFalse(@Param("taskId")Long id);
 
-    int countByProjectIdAndStatus(Long projectId, TaskStatus status);
-    int countByProjectIdAndStatusIn(Long projectId, List<TaskStatus> statuses); // 완료, 미완료 task 조회
 
     // dashboard에서 사용
     List<Task> findByMemberUserIdAndDueDateBetweenAndIsDeletedFalse(
@@ -77,6 +75,7 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             "GROUP BY m.user.id")
     List<Object[]> countCompletedTasksByUserIdsInCompletedProjects(@Param("userIds") List<Long> userIds);
     // 프로필페이지 특정 user의 테스크 개수 반환
+
     int countByProjectIdAndMemberIdAndStatus(
             Long projectId,
             Long memberId,


### PR DESCRIPTION
1. 개요
최대 인원 충족 에 따른 프로젝트 가동 자동화 로직을 구현. 
모집글 인원 충족 -> 프로젝트 ACTIVE
모집글 기한 만료 -> 프로젝트 삭제

또한, 전체 팀 찾기 및 북마크 조회 시 지원 상태(합격/탈락&대기 중)에 따른 보안 방어 로직을 추가.

2. 주요 변경 사항 
모집글 생성 및 기간 설정 간소화 (RecruitCreateRequest, RecruitService)

모집글 생성 시 모집글 deadline(마감일)과 startDate(시작일) 입력을 전면 제거하고, 프로젝트 종료일(endDate)만 필수 입력받도록 스펙을 변경.

자동 생성 로직: 모집글 등록 시 백엔드 내부에서 마감 기한을 현재 시간 + 7일로 자동 산출하여 Recruit 엔티티를 생성.

스케줄러 기반의 모집글 라이프사이클 자동화 
RecruitScheduler <- 5분 주기로 마감일감시
ProjectScheduler <- 하루 주기로 마감일 감시

기간 만료 처리 (processExpiration): 데드라인을 넘긴 모집글은 EXPIRED 상태로 변경하되, 매칭 실패한 임시 Project와 유령 멤버 데이터는 DB에서 Hard Delete함.

인원 완판 자동 마감 (processCompletion): 지원서 승인 시 팀 인원이 다 차면 즉시 모집글을 내리고 임시 프로젝트를 ACTIVE 상태로 전환하며, 가동 순간의 LocalDate.now()를 프로젝트 시작일(startDate)로 동적 주입.

지원 상태별 프로젝트 접근 권한 제어 (RecruitResponse, RecruitSuccessCode)
탈락자/미지원자 원천 차단: 북마크 및 팀 찾기 목록 조회 API에서 글쓴이(팀장)이거나 최종 합격(ACCEPTED)한 유저가 아닐 경우 projectId를 null로 변환하여 반환.