### PR TITLE
[feat] 공통 - 페이지네이션 컴포넌트 구현 및 페이지 적용

### DIFF
--- a/FE/src/components/Pagination/Pagination.css
+++ b/FE/src/components/Pagination/Pagination.css
@@ -1,0 +1,40 @@
+.pagination-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  margin-top: 32px;
+  margin-bottom: 32px;
+}
+
+.pagination-btn {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid #E5E5E5;
+  background-color: #FFFFFF;
+  color: #555555;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.pagination-btn:hover:not(:disabled) {
+  background-color: #F5F5F5;
+}
+
+.pagination-btn.active {
+  background-color: #FE9A57;
+  color: #FFFFFF;
+  border-color: #FE9A57;
+  font-weight: bold;
+}
+
+.pagination-btn:disabled {
+  background-color: #F9F9F9;
+  color: #CCCCCC;
+  cursor: not-allowed;
+}

--- a/FE/src/components/Pagination/Pagination.jsx
+++ b/FE/src/components/Pagination/Pagination.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import './Pagination.css';
+
+function Pagination({ currentPage, totalPages, onPageChange }) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="pagination-container">
+      <button
+        className="pagination-btn"
+        onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
+        disabled={currentPage === 1}
+      >
+        &lt;
+      </button>
+      {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+        <button
+          key={page}
+          className={`pagination-btn ${currentPage === page ? 'active' : ''}`}
+          onClick={() => onPageChange(page)}
+        >
+          {page}
+        </button>
+      ))}
+      <button
+        className="pagination-btn"
+        onClick={() => onPageChange(Math.min(currentPage + 1, totalPages))}
+        disabled={currentPage === totalPages}
+      >
+        &gt;
+      </button>
+    </div>
+  );
+}
+
+export default Pagination;

--- a/FE/src/pages/FindTeam/FindTeamPage.jsx
+++ b/FE/src/pages/FindTeam/FindTeamPage.jsx
@@ -1,7 +1,8 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import ApplyModal from "../../components/ApplyModal/ApplyModal.jsx";
 import Badge from "../../components/Badge/Badge.jsx";
 import ApplicantBox from "../../components/ApplicantBox/ApplicantBox.jsx";
+import Pagination from "../../components/Pagination/Pagination.jsx";
 import "./FindTeamPage.css";
 
 const KOREAN_INITIALS = [
@@ -117,6 +118,12 @@ function FindTeamPage() {
   const [selectedTeamId, setSelectedTeamId] = useState(null);
   const [job, setJob] = useState("");
   const [motivation, setMotivation] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const ITEMS_PER_PAGE = 10;
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [selectedCategory, searchKeyword]);
 
   const filteredTeamPosts = useMemo(() => {
     const keyword = searchKeyword.trim();
@@ -129,6 +136,12 @@ function FindTeamPage() {
         team.applyStatus !== "rejected",
     );
   }, [selectedCategory, searchKeyword, teamPosts]);
+
+  const totalPages = Math.ceil(filteredTeamPosts.length / ITEMS_PER_PAGE) || 1;
+  const currentTeamPosts = filteredTeamPosts.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE
+  );
 
   const selectedTeam = teamPosts.find((team) => team.id === selectedTeamId);
   const isApplyModalOpen = selectedTeamId !== null;
@@ -195,8 +208,8 @@ function FindTeamPage() {
       </div>
 
       <section className="find-team-list" aria-label="팀 목록">
-        {filteredTeamPosts.length > 0 ? (
-          filteredTeamPosts.map((team) => {
+        {currentTeamPosts.length > 0 ? (
+          currentTeamPosts.map((team) => {
             let buttonText = "지원하기";
             let buttonColor = "#FE9A57";
             let buttonTextColor = "#FFFFFF";
@@ -227,6 +240,14 @@ function FindTeamPage() {
           <div className="find-team-empty">해당 카테고리에 모집중인 팀이 없습니다.</div>
         )}
       </section>
+
+      {filteredTeamPosts.length > 0 && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
+      )}
 
       <ApplyModal
         isOpen={isApplyModalOpen}

--- a/FE/src/pages/ProjectPage/ProjectPage.jsx
+++ b/FE/src/pages/ProjectPage/ProjectPage.jsx
@@ -4,6 +4,7 @@ import ProjectBox from '../../components/ProjectBox/ProjectBox';
 import ApplicantBox from '../../components/ApplicantBox/ApplicantBox';
 import ApplyModal from '../../components/ApplyModal/ApplyModal';
 import { getAppliedProjects, getBookmarkedProjects, getActiveProjects, getCompletedProjects } from '../../api/Project/projectApi';
+import Pagination from '../../components/Pagination/Pagination';
 import './ProjectPage.css';
 
 const tabs = [
@@ -24,6 +25,8 @@ function ProjectPage() {
   const [selectedProjectForApply, setSelectedProjectForApply] = useState(null);
   const [applyJob, setApplyJob] = useState('');
   const [applyMotivation, setApplyMotivation] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const ITEMS_PER_PAGE = 10;
 
   useEffect(() => {
     const token = localStorage.getItem('accessToken');
@@ -69,7 +72,7 @@ function ProjectPage() {
 
     const fetchBookmarkedProjects = async () => {
       try {
-        const response = await getBookmarkedProjects(0, 10);
+        const response = await getBookmarkedProjects(0, ITEMS_PER_PAGE);
         if (response.data && response.data.isSuccess) {
           const fetchedData = response.data.data.content.map((item) => {
             let mappedStatus = null;
@@ -181,6 +184,12 @@ function ProjectPage() {
     });
   }, [activeTab, projects, appliedProjects, activeProjects, completedProjects]);
 
+  const totalPages = Math.ceil(filteredProjects.length / ITEMS_PER_PAGE);
+  const currentProjects = filteredProjects.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE
+  );
+
   const handleCloseApplyModal = () => {
     setIsApplyModalOpen(false);
     setSelectedProjectForApply(null);
@@ -198,7 +207,10 @@ function ProjectPage() {
             <div 
               key={tab.key} 
               className={`tab-item ${activeTab === tab.key ? 'active' : ''}`}
-              onClick={() => setActiveTab(tab.key)}
+              onClick={() => {
+                setActiveTab(tab.key);
+                setCurrentPage(1);
+              }}
             >
               {tab.label}
             </div>
@@ -207,7 +219,7 @@ function ProjectPage() {
 
         <div className="project-list">
           {filteredProjects.length > 0 ? (
-            filteredProjects.map((project) => {
+            currentProjects.map((project) => {
               // 합격한 경우에 한해 존재하는 projectId로 이동 처리. 대기 중/탈락은 기존 id 활용
               const targetId = (project.applyStatus === 'accepted' && project.projectId) ? project.projectId : project.id;
 
@@ -300,6 +312,14 @@ function ProjectPage() {
             <div className="project-empty">해당하는 프로젝트가 없습니다.</div>
           )}
         </div>
+        
+        {filteredProjects.length > 0 && (
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+          />
+        )}
       </div>
 
       <ApplyModal


### PR DESCRIPTION
## 📌 개요
페이지네이션 컴포넌트 구현하고 프로젝트 페이지/팀찾기 페이지 각각 페이지당 10개씩 확인할 수 있도록 적용했습니다.

## ⚙️ 작업 내용
- 페이지네이션 컴포넌트 구현
- 프로젝트 페이지에 페이지네이션 적용 (탭 바뀌면 1번째 페이지로 리셋)
- 팀찾기 페이지에 페이지네이션 적용 (검색어 바뀌는 경우 1번째 페이지로 리셋)
<img width="600" alt="image" src="https://github.com/user-attachments/assets/641e7a55-47de-4f2d-bbe1-3b42c0076541" />

 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
