### PR TITLE
[fix] MemberRepository 단일 조회 오류 수정

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/project/repository/MemberRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/repository/MemberRepository.java
@@ -31,7 +31,7 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
             @Param("status") ProjectStatus status
     );
 
-    Optional<Member> findByUserId(Long userId);
+    List<Member> findByUserId(Long userId);
 
     List<Member> findAllByProjectIdAndIsDeletedFalse(Long projectId);
 


### PR DESCRIPTION
## 📌 개요
MemberRepository의 단일 조회 오류를 수정하였습니다.

## ⚙️ 작업 내용
- MemberRepository의 findByUserId 반환 타입을 Optional<Member>에서 List<Member>로 변경
 
## 🎸 기타사항

