### PR TITLE
[fix] 팀 제작 페이지 - 클래스명 충돌로 인한 CSS 적용 오류 수정 및 디자인 수정

### DIFF
--- a/FE/src/pages/Teammaking/TeammakingPage.css
+++ b/FE/src/pages/Teammaking/TeammakingPage.css
@@ -11,7 +11,7 @@ body {
 
 .page-wrapper {
   width: 100%;
-  height: 100%;
+  height: calc(100vh - 56px);
   overflow: hidden;
   background-color: #f8f8f8;
   padding: 19px 50px 20px 30px;

--- a/FE/src/pages/Teammaking/TeammakingPage.css
+++ b/FE/src/pages/Teammaking/TeammakingPage.css
@@ -35,7 +35,7 @@ body {
   border-radius: 9px;
   width: 864px;
   max-width: 100%;
-  height: 593px;
+  height: 599px;
   padding: 19px 33px;
   margin: 0;
   position: relative;
@@ -455,7 +455,7 @@ body {
 
   .card {
     width: 100%;
-    height: 585px;
+    height: 599px;
     border-radius: 9px;
     padding: 20px 18px;
   }
@@ -465,13 +465,13 @@ body {
   }
 
   .form-field {
-    margin-bottom: 16px;
+    margin-bottom: 19px;
   }
 
   .teammaking-form-label {
     font-size: 14px;
     line-height: 18px;
-    margin-bottom: 9px;
+    margin-bottom: 0px;
   }
 
   .text-input,

--- a/FE/src/pages/Teammaking/TeammakingPage.css
+++ b/FE/src/pages/Teammaking/TeammakingPage.css
@@ -465,13 +465,13 @@ body {
 
   .card {
     width: 100%;
-    height: 599px;
+    height: 585px;
     border-radius: 9px;
-    padding: 20px 18px;
+    padding: 22px 18px;
   }
 
   .teammaking-logo-box {
-    margin-bottom: 16px;
+    display: none;
   }
 
   .form-field {

--- a/FE/src/pages/Teammaking/TeammakingPage.css
+++ b/FE/src/pages/Teammaking/TeammakingPage.css
@@ -18,7 +18,7 @@ body {
   background: linear-gradient(180deg, #f0f0f0 0%, #ffffff 100%);
 }
 
-.page-title {
+.teammaking-page-title {
   width: 864px;
   max-width: 100%;
   margin: 0 0 20px;
@@ -445,7 +445,7 @@ body {
     padding: 16px 14px 0;
   }
 
-  .page-title {
+  .teammaking-page-title {
     width: 100%;
     font-size: 21px;
     line-height: 27px;

--- a/FE/src/pages/Teammaking/TeammakingPage.css
+++ b/FE/src/pages/Teammaking/TeammakingPage.css
@@ -307,6 +307,16 @@ body {
   background: #4f67a3;
 }
 
+.date-picker-day:disabled {
+  color: #d1d1d1;
+  cursor: not-allowed;
+}
+
+.date-picker-day:disabled:hover {
+  background: transparent;
+  color: #d1d1d1;
+}
+
 .date-picker-actions {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/FE/src/pages/Teammaking/TeammakingPage.css
+++ b/FE/src/pages/Teammaking/TeammakingPage.css
@@ -21,7 +21,7 @@ body {
 .page-title {
   width: 864px;
   max-width: 100%;
-  margin: 0 0 18px;
+  margin: 0 0 20px;
   margin-left: 0;
   font-size: 22px;
   line-height: 27px;
@@ -35,48 +35,48 @@ body {
   border-radius: 9px;
   width: 864px;
   max-width: 100%;
-  height: 560px;
-  padding: 27px 33px;
+  height: 593px;
+  padding: 19px 33px;
   margin: 0;
   position: relative;
   box-shadow: 0 10px 28px rgba(0, 0, 0, 0.04);
 }
 
 .teammaking-logo-box {
-  width: 36px;
-  height: 36px;
+  width: 48px;
+  height: 48px;
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 14px;
-  border-radius: 4px;
+  margin-bottom: 18px;
+  border-radius: 6px;
   background-color: #f0f0f0;
 }
 
 .teammaking-logo-box img {
-  width: 28px;
-  height: 28px;
+  width: 36px;
+  height: 36px;
   filter: grayscale(1);
   opacity: 0.24;
 }
 
 .form-field {
-  margin-bottom: 16px;
+  margin-bottom: 20px;
 }
 
-.form-label {
+.teammaking-form-label {
   display: block;
-  font-size: 14px;
+  font-size: 16px;
   line-height: 18px;
-  font-weight: 800;
+  font-weight: 600;
   color: #1a1a1a;
-  margin-bottom: 9px;
+  margin-bottom: 2px;
 }
 
 .text-input {
   width: 507px;
   max-width: 100%;
-  height: 32px;
+  height: 33px;
   padding: 0 11px;
   border: 1px solid #bcbcbc;
   border-radius: 3px;
@@ -127,7 +127,7 @@ body {
 }
 
 .project-period-field {
-  margin-bottom: 16px;
+  margin-bottom: 20px;
 }
 
 .project-period-row {
@@ -143,7 +143,7 @@ body {
   position: relative;
   display: block;
   min-width: 0;
-  height: 44px;
+  height: 33px;
   padding: 0;
   border: 0;
   background: transparent;
@@ -156,13 +156,13 @@ body {
   width: 100%;
   height: 100%;
   padding: 6px 10px;
-  border: 2px solid #bcbcbc;
-  border-radius: 9px;
+  border: 1px solid #bcbcbc;
+  border-radius: 3px;
   background: #f3f3f3;
   color: #1a1a1a;
   display: flex;
   align-items: center;
-  white-space: pre-line;
+  white-space: nowrap;
   font-size: 16px;
   font-weight: 500;
   line-height: 1.05;
@@ -233,7 +233,7 @@ body {
   display: grid;
   grid-template-columns: 40px 1fr 40px;
   align-items: center;
-  margin-bottom: 24px;
+  margin-bottom: 28px;
 }
 
 .date-picker-monthbar strong {
@@ -262,7 +262,7 @@ body {
 }
 
 .date-picker-weekdays {
-  margin-bottom: 16px;
+  margin-bottom: 18px;
 }
 
 .date-picker-weekdays span {
@@ -373,71 +373,72 @@ body {
 
 .bottom-bar {
   position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  margin-top: 20px;
-  padding: 20px 40px;
+  bottom: 12px;
+  right: 33px;
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  
-  border-radius: 0 0 16px 16px;
 }
 
-.action-buttons {
+.teammaking-actions {
   display: flex;
   gap: 15px;
 }
 
-.btn-cancel {
-  height: 48px;
-  padding: 0 28px;
-  border-radius: 10px;
+.teammaking-btn-cancel {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 41px;
+  padding: 10px 20px;
+  gap: 10px;
   border: none;
-  background-color: #e0e0e0;
-  color: #555555;
-  font-size: 15px;
-  font-weight: 600;
+  border-radius: 5px;
+  background: #d9d9d9;
+  color: #ffffff;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 21px;
   cursor: pointer;
-  transition: background-color 0.18s ease;
-  font-family: inherit;
+  font-family: "Pretendard", sans-serif;
+  transition: background 0.15s;
 }
 
-.btn-cancel:hover {
-  background-color: #d4d4d4;
+.teammaking-btn-cancel:hover {
+  background: #c4c4c4;
 }
 
-.btn-submit {
-  height: 48px;
-  padding: 0 28px;
-  border-radius: 10px;
+.teammaking-btn-submit {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  width: 111px;
+  height: 41px;
+  padding: 10px 24px;
+  gap: 10px;
   border: none;
-  background-color: #f3841e;
+  border-radius: 5px;
+  background: #fe9a57;
   color: #ffffff;
-  font-size: 15px;
-  font-weight: 600;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 21px;
   cursor: pointer;
-  transition: background-color 0.18s ease, transform 0.1s ease;
-  font-family: inherit;
+  font-family: "Pretendard", sans-serif;
+  transition: background 0.15s;
 }
 
-.btn-submit:hover {
-  background-color: #e07519;
+.teammaking-btn-submit:hover {
+  background: #f08040;
 }
 
-.btn-submit:disabled {
-  background-color: #d9d9d9;
-  color: #ffffff;
+.teammaking-btn-submit:disabled {
+  background: #d9d9d9;
   cursor: not-allowed;
-  opacity: 1;
 }
-
-.btn-submit:disabled:hover {
-  background-color: #d9d9d9;
-}
-
-
 
 @media (max-width: 768px) {
   .page-wrapper {
@@ -454,20 +455,20 @@ body {
 
   .card {
     width: 100%;
-    height: min(560px, calc(100dvh - 105px));
+    height: 585px;
     border-radius: 9px;
-    padding: 27px 18px;
+    padding: 20px 18px;
   }
 
   .teammaking-logo-box {
-    margin-bottom: 14px;
+    margin-bottom: 16px;
   }
 
   .form-field {
-    margin-bottom: 14px;
+    margin-bottom: 16px;
   }
 
-  .form-label {
+  .teammaking-form-label {
     font-size: 14px;
     line-height: 18px;
     margin-bottom: 9px;
@@ -504,12 +505,12 @@ body {
   }
 
   .period-date-picker {
-    height: 42px;
+    height: 33px;
   }
 
   .period-date-display {
     padding: 6px 8px;
-    border-radius: 8px;
+    border-radius: 3px;
     font-size: 15px;
   }
 
@@ -580,18 +581,7 @@ body {
   .bottom-bar {
     position: absolute;
     right: 18px;
-    bottom: 8px;
+    bottom: 12px;
   }
 
-  .action-buttons {
-    gap: 15px;
-  }
-
-  .btn-cancel,
-  .btn-submit {
-    flex: 0 0 126px;
-    width: 126px;
-    height: 54px;
-    font-size: 18px;
-  }
 }

--- a/FE/src/pages/Teammaking/TeammakingPage.jsx
+++ b/FE/src/pages/Teammaking/TeammakingPage.jsx
@@ -77,7 +77,7 @@ function TeammakingPage() {
           onDomainChange={setSelectedDomain}
         />
         <div className="form-field recruit-count-field">
-          <label className="form-label" htmlFor="recruit-count">
+          <label className="teammaking-form-label" htmlFor="recruit-count">
             모집 인원
           </label>
           <select

--- a/FE/src/pages/Teammaking/TeammakingPage.jsx
+++ b/FE/src/pages/Teammaking/TeammakingPage.jsx
@@ -62,7 +62,7 @@ function TeammakingPage() {
 
   return (
     <div className="page-wrapper">
-      <h1 className="page-title">프로젝트 생성</h1>
+      <h1 className="teammaking-page-title">프로젝트 생성</h1>
       <div className="card">
         <div className="teammaking-logo-box" aria-hidden="true">
           <img src={logoIcon} alt="" />

--- a/FE/src/pages/Teammaking/components/DomainSelector.jsx
+++ b/FE/src/pages/Teammaking/components/DomainSelector.jsx
@@ -3,7 +3,7 @@
 function DomainSelector({ domainOptions, selectedDomain, onDomainChange }) {
   return (
     <div className="form-field">
-      <label className="form-label">분야 설정</label>
+      <label className="teammaking-form-label">분야 설정</label>
       <div className="domain-tags">
         {domainOptions.map((option) => (
           <Badge

--- a/FE/src/pages/Teammaking/components/FormActions.jsx
+++ b/FE/src/pages/Teammaking/components/FormActions.jsx
@@ -1,13 +1,13 @@
 function FormActions({ onCancel, onSubmit, isSubmitEnabled }) {
   return (
     <div className="bottom-bar">
-      <div className="action-buttons">
-        <button type="button" className="btn-cancel" onClick={onCancel}>
+      <div className="teammaking-actions">
+        <button type="button" className="teammaking-btn-cancel" onClick={onCancel}>
           취소
         </button>
         <button
           type="button"
-          className="btn-submit"
+          className="teammaking-btn-submit"
           onClick={onSubmit}
           disabled={!isSubmitEnabled}
         >

--- a/FE/src/pages/Teammaking/components/ProjectDescriptionField.jsx
+++ b/FE/src/pages/Teammaking/components/ProjectDescriptionField.jsx
@@ -1,7 +1,7 @@
 ﻿function ProjectDescriptionField({ description, onDescriptionChange }) {
   return (
     <div className="form-field">
-      <label className="form-label">프로젝트 설명</label>
+      <label className="teammaking-form-label">프로젝트 설명</label>
       <textarea
         className="textarea-input"
         value={description}

--- a/FE/src/pages/Teammaking/components/ProjectNameField.jsx
+++ b/FE/src/pages/Teammaking/components/ProjectNameField.jsx
@@ -1,7 +1,7 @@
 ﻿function ProjectNameField({ projectName, onProjectNameChange }) {
   return (
     <div className="form-field">
-      <label className="form-label">프로젝트 이름</label>
+      <label className="teammaking-form-label">프로젝트 이름</label>
       <input
         type="text"
         className="text-input"

--- a/FE/src/pages/Teammaking/components/ProjectPeriodField.jsx
+++ b/FE/src/pages/Teammaking/components/ProjectPeriodField.jsx
@@ -105,6 +105,8 @@ function ProjectPeriodField({ startDate, endDate, onStartDateChange, onEndDateCh
     closePicker();
   };
 
+  const todayStr = toDateValue(new Date());
+
   return (
     <div className="form-field project-period-field">
       <span className="teammaking-form-label">프로젝트 기간</span>
@@ -176,6 +178,13 @@ function ProjectPeriodField({ startDate, endDate, onStartDateChange, onEndDateCh
 
                   const value = toDateValue(date);
                   const isSelected = value === draftDate;
+                  let isDisabled = false;
+
+                  if (pickerTarget === 'start') {
+                    isDisabled = value < todayStr;
+                  } else if (pickerTarget === 'end') {
+                    isDisabled = value < (startDate || todayStr);
+                  }
 
                   return (
                     <button
@@ -183,6 +192,7 @@ function ProjectPeriodField({ startDate, endDate, onStartDateChange, onEndDateCh
                       type="button"
                       className={isSelected ? 'date-picker-day date-picker-day--selected' : 'date-picker-day'}
                       onClick={() => selectDay(date)}
+                      disabled={isDisabled}
                     >
                       {date.getDate()}
                     </button>

--- a/FE/src/pages/Teammaking/components/ProjectPeriodField.jsx
+++ b/FE/src/pages/Teammaking/components/ProjectPeriodField.jsx
@@ -107,7 +107,7 @@ function ProjectPeriodField({ startDate, endDate, onStartDateChange, onEndDateCh
 
   return (
     <div className="form-field project-period-field">
-      <span className="form-label">프로젝트 기간</span>
+      <span className="teammaking-form-label">프로젝트 기간</span>
 
       <div className="project-period-row">
         <button


### PR DESCRIPTION
## 📌 개요
클래스명 중복으로 인해 다른 페이지의 CSS가 의도치 않게 적용되는 문제를 보완하고 일부 UI 수정했습니다.

## ⚙️ 작업 내용
- 중복되는 클래스명 변경
- 일부 UI 디자인 수정
- 스크롤 제거를 위한 화면 높이 조절
- 모집 기간 검증 로직 구현

### pc 버전
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/97221490-cf36-426b-b623-4d8d0245b20f" />

 ### 모바일(아이폰 XR)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/366c63c4-ae37-43a1-bfb8-0cf713fd8739" />

 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
