### PR TITLE
[feat] 팀 제작 페이지 - 모집 게시글 생성 API 연동

### DIFF
--- a/FE/src/pages/Teammaking/TeammakingPage.jsx
+++ b/FE/src/pages/Teammaking/TeammakingPage.jsx
@@ -1,18 +1,20 @@
 ﻿import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import logoIcon from "../../assets/logoIcon.svg";
 import DomainSelector from "./components/DomainSelector.jsx";
 import FormActions from "./components/FormActions.jsx";
 import ProjectDescriptionField from "./components/ProjectDescriptionField.jsx";
 import ProjectNameField from "./components/ProjectNameField.jsx";
 import ProjectPeriodField from "./components/ProjectPeriodField.jsx";
+import apiClient from "../../api/apiClient.js";
 import "./TeammakingPage.css";
 
 const domainOptions = [
-  { id: "assignment", label: "조별과제" },
-  { id: "study", label: "스터디" },
-  { id: "contest", label: "공모전" },
-  { id: "dev", label: "개발" },
-  { id: "etc", label: "기타" },
+  { id: "PROJECT", label: "조별과제" },
+  { id: "STUDY", label: "스터디" },
+  { id: "CONTEST", label: "공모전" },
+  { id: "DEV", label: "개발" },
+  { id: "ETC", label: "기타" },
 ];
 
 const getTodayValue = () => {
@@ -23,9 +25,10 @@ const getTodayValue = () => {
 };
 
 function TeammakingPage() {
+  const navigate = useNavigate();
   const todayValue = getTodayValue();
   const [projectName, setProjectName] = useState("");
-  const [selectedDomain, setSelectedDomain] = useState("assignment");
+  const [selectedDomain, setSelectedDomain] = useState("PROJECT");
   const [recruitCount, setRecruitCount] = useState("1");
   const [startDate, setStartDate] = useState(todayValue);
   const [endDate, setEndDate] = useState(todayValue);
@@ -34,7 +37,7 @@ function TeammakingPage() {
 
   const handleCancel = () => {
     setProjectName("");
-    setSelectedDomain("assignment");
+    setSelectedDomain("PROJECT");
     setRecruitCount("1");
     setStartDate(todayValue);
     setEndDate(todayValue);
@@ -49,15 +52,28 @@ function TeammakingPage() {
     }
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!isSubmitEnabled) return;
 
-    const selectedDomainLabel =
-      domainOptions.find((option) => option.id === selectedDomain)?.label ?? selectedDomain;
+    try {
+      const payload = {
+        title: projectName,
+        description: description,
+        category: selectedDomain,
+        totalSlots: parseInt(recruitCount, 10),
+        startDate: startDate,
+        endDate: endDate,
+      };
 
-    alert(
-      `프로젝트 생성!\n이름: ${projectName}\n분야: ${selectedDomainLabel}\n모집 인원: ${recruitCount}명\n기간: ${startDate} ~ ${endDate}\n설명: ${description}`,
-    );
+      const response = await apiClient.post("/recruitments", payload);
+      if (response.data && response.data.isSuccess) {
+        alert("팀 모집 게시글 발행을 성공했습니다.");
+        navigate(-1);
+      }
+    } catch (error) {
+      console.error("팀 모집 게시글 생성 실패:", error);
+      alert(error.message || "팀 모집 게시글 생성 중 오류가 발생했습니다.");
+    }
   };
 
   return (


### PR DESCRIPTION
## 📌 개요
팀메이킹 페이지 API 연동했습니다.

## ⚙️ 작업 내용
- 모집 게시글 생성 api 연동
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
