### PR TITLE
[feat] 지원자 검토 페이지 - 페이지네이션 및 상세 페이지 라우팅 적용

### DIFF
--- a/FE/src/components/AddEventModal/AddEventModal.css
+++ b/FE/src/components/AddEventModal/AddEventModal.css
@@ -68,7 +68,7 @@
 .title-input {
   box-sizing: border-box;
   width: 100%;
-  height: 40px;
+  height: 33px;
   background: #F1F1F1;
   border: 1px solid #ABABAB;
   border-radius: 5px;
@@ -106,7 +106,7 @@
   padding: 0px;
   gap: 10px;
   width: 100%;
-  height: 40px;
+  height: 33px;
 }
 
 .row-label {
@@ -124,7 +124,7 @@
 .custom-date-picker {
   position: relative;
   width: 200px;
-  height: 40px;
+  height: 33px;
   flex-grow: 0;
 }
 
@@ -164,7 +164,7 @@
 
 .time-input {
   width: 64px;
-  height: 40px;
+  height: 33px;
   background: #FFFFFF;
   border: none;
   border-radius: 5px;

--- a/FE/src/components/ApplyModal/ApplyModal.css
+++ b/FE/src/components/ApplyModal/ApplyModal.css
@@ -69,7 +69,7 @@
 }
 
 .apply-modal-input {
-  height: 40px;
+  height: 33px;
   padding: 10px 12px;
 }
 

--- a/FE/src/pages/Applicant/ApplicantList.jsx
+++ b/FE/src/pages/Applicant/ApplicantList.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ApplicantBox from '../../components/ApplicantBox/ApplicantBox';
+import Pagination from '../../components/Pagination/Pagination';
 import { getMyRecruitments } from '../../api/RecruitApi';
 import './Applicant.css';
 
@@ -12,10 +13,13 @@ const CATEGORY_LABEL = {
   ETC: '기타',
 };
 
+const ITEMS_PER_PAGE = 10;
+
 const ApplicantList = () => {
   const navigate = useNavigate();
   const [recruitments, setRecruitments] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
     setLoading(true);
@@ -28,6 +32,12 @@ const ApplicantList = () => {
       .finally(() => setLoading(false));
   }, []);
 
+  const totalPages = Math.ceil(recruitments.length / ITEMS_PER_PAGE);
+  const currentRecruitments = recruitments.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE
+  );
+
   return (
     <main className="al-page">
       <h1 className="al-title">지원자 검토</h1>
@@ -35,7 +45,7 @@ const ApplicantList = () => {
       {loading && <p style={{ padding: '20px' }}>불러오는 중...</p>}
 
       <section className="al-list">
-        {recruitments.map((recruitment) => {
+        {!loading && currentRecruitments.map((recruitment) => {
           const isClosed = recruitment.status === 'COMPLETED' || recruitment.status === 'CANCELLED';
           return (
             <ApplicantBox
@@ -62,6 +72,14 @@ const ApplicantList = () => {
           );
         })}
       </section>
+
+      {!loading && recruitments.length > 0 && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
+      )}
     </main>
   );
 };

--- a/FE/src/pages/Applicant/ApplicantList.jsx
+++ b/FE/src/pages/Applicant/ApplicantList.jsx
@@ -47,9 +47,10 @@ const ApplicantList = () => {
       <section className="al-list">
         {!loading && currentRecruitments.map((recruitment) => {
           const isClosed = recruitment.status === 'COMPLETED' || recruitment.status === 'CANCELLED';
+          const targetId = recruitment.recruitmentId || recruitment.id || recruitment.postId;
           return (
             <ApplicantBox
-              key={recruitment.postId}
+              key={targetId}
               title={recruitment.title}
               summary={CATEGORY_LABEL[recruitment.category] ?? recruitment.category}
               capacity={recruitment.maxMember}
@@ -57,13 +58,14 @@ const ApplicantList = () => {
               buttonText={isClosed ? '모집 마감' : '지원자 검토'}
               buttonColor={isClosed ? '#D9D9D9' : '#FE9A57'}
               disabled={isClosed}
+              onClick={() => navigate(`/readme/${targetId}`, { state: recruitment })}
               onButtonClick={
                 isClosed
                   ? undefined
                   : () =>
                       navigate('/applicant/detail', {
                         state: {
-                          recruitmentId: recruitment.postId,
+                          recruitmentId: targetId,
                           projectTitle: recruitment.title,
                         },
                       })

--- a/FE/src/pages/ProfilePage/components/AddProjectModal.css
+++ b/FE/src/pages/ProfilePage/components/AddProjectModal.css
@@ -64,7 +64,7 @@
 .add-modal-input {
   box-sizing: border-box;
   width: 100%;
-  height: 40px;
+  height: 33px;
   background: #F1F1F1;
   border: 1px solid #ABABAB;
   border-radius: 5px;


### PR DESCRIPTION
## 📌 개요
지원자 검토 페이지에 페이지네이션을 추가하고 프로젝트 클릭 시 프로젝트 설명 페이지로 이동하도록 설정했습니다.

## ⚙️ 작업 내용
- 페이지네이션 10개씩 동작 구현
- 프로젝트 항목 클릭 시 프로젝트 설명 페이지 이동 라우팅 설정
- 모달창 입력칸 높이 통일
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
