### PR TITLE
[feat] 공통 - 비로그인시, 헤더 로그인 버튼 생성 및 접근 제한 추가

### DIFF
--- a/FE/src/components/Header/Header.css
+++ b/FE/src/components/Header/Header.css
@@ -98,6 +98,43 @@
   font-size: 16px;
 }
 
+.header-login-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 16px;
+  background-color: #FFFFFF;
+  color: #333333;
+  border: 1px solid #D9D9D9;
+  font-family: 'Pretendard', sans-serif;
+  font-size: 15px;
+  font-weight: 700;
+  border-radius: 20px;
+}
+
+.header-login-btn:hover {
+  border-color: #FE9A57;
+  color: #FE9A57;
+}
+
+.header-login-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.header-login-icon.hover-icon {
+  display: none;
+}
+
+.header-login-btn:hover .header-login-icon.default-icon {
+  display: none;
+}
+
+.header-login-btn:hover .header-login-icon.hover-icon {
+  display: block;
+}
+
 @media (max-width: 768px) {
   .hamburger-btn {
     display: flex;

--- a/FE/src/components/Header/Header.jsx
+++ b/FE/src/components/Header/Header.jsx
@@ -2,14 +2,23 @@ import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { getUserInfo } from '../../api/User/userProfileApi.js';
 import logoImg from '../../assets/logoOrange.svg';
+import profileIcon from '../../assets/icons/profileIcon.svg';
+import profileIconHover from '../../assets/icons/profileOrangeIcon.svg';
 import ProfileAvatar from '../ProfileAvatar/ProfileAvatar';
 import './Header.css';
 
 function Header({ onMenuClick }) {
   const [userData, setUserData] = useState({ userName: "..." });
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   useEffect(() => {
     const fetchUserData = async () => {
+      const token = localStorage.getItem("accessToken");
+      if (!token) {
+        setIsLoggedIn(false);
+        return;
+      }
+
       try {
         const response = await getUserInfo();
         const name = response?.data?.userName || "사용자";
@@ -17,8 +26,10 @@ function Header({ onMenuClick }) {
         setUserData({
           userName: name
         });
+        setIsLoggedIn(true);
       } catch (error) {
         console.error("유저 정보 로드 실패", error);
+        setIsLoggedIn(false);
       }
     };
     fetchUserData();
@@ -40,12 +51,22 @@ function Header({ onMenuClick }) {
       </div>
 
       <div className="header-right">
-        <Link to="/profile" className="header-greeting">
-          <strong>{userData.userName}</strong> 님 안녕하세요 :)
-        </Link>
-        <Link to="/profile">
-          <ProfileAvatar size="36px" />
-        </Link>
+        {isLoggedIn ? (
+          <>
+            <Link to="/profile" className="header-greeting">
+              <strong>{userData.userName}</strong> 님 안녕하세요 :)
+            </Link>
+            <Link to="/profile">
+              <ProfileAvatar size="36px" />
+            </Link>
+          </>
+        ) : (
+          <Link to="/login" className="header-login-btn">
+            <img src={profileIcon} alt="" className="header-login-icon default-icon" />
+            <img src={profileIconHover} alt="" className="header-login-icon hover-icon" />
+            로그인
+          </Link>
+        )}
       </div>
     </header>
   );

--- a/FE/src/pages/Applicant/ApplicantList.jsx
+++ b/FE/src/pages/Applicant/ApplicantList.jsx
@@ -18,6 +18,13 @@ const ApplicantList = () => {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
+    const token = localStorage.getItem('accessToken');
+    if (!token) {
+      alert('로그인이 필요한 서비스입니다.');
+      navigate(-1);
+      return;
+    }
+
     setLoading(true);
     getMyRecruitments()
       .then((res) => {
@@ -26,7 +33,7 @@ const ApplicantList = () => {
       })
       .catch((err) => console.error('모집글 목록 조회 실패', err))
       .finally(() => setLoading(false));
-  }, []);
+  }, [navigate]);
 
   return (
     <main className="al-page">

--- a/FE/src/pages/FindTeam/FindTeamPage.jsx
+++ b/FE/src/pages/FindTeam/FindTeamPage.jsx
@@ -110,6 +110,13 @@ function FindTeamPage() {
   };
 
   const handleOpenApplyModal = (teamId) => {
+    const token = localStorage.getItem('accessToken');
+    if (!token) {
+      alert('로그인이 필요한 서비스입니다.');
+      navigate(-1);
+      return;
+    }
+
     setSelectedTeamId(teamId);
     setJob("");
     setMotivation("");

--- a/FE/src/pages/ProfilePage/ProfilePage.jsx
+++ b/FE/src/pages/ProfilePage/ProfilePage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import apiClient from '../../api/apiClient';
 import MainButton from '../../components/MainButton/MainButton';
 import Avatar from '../../components/Avatar/Avatar';
@@ -10,6 +11,7 @@ const ProfilePage = () => {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [profileImageUrl, setProfileImageUrl] = useState(null);
   const fileInputRef = useRef(null);
+  const navigate = useNavigate();
 
   const [userInfo, setUserInfo] = useState({
     name: '로딩 중...',
@@ -25,6 +27,13 @@ const ProfilePage = () => {
   };
 
   useEffect(() => {
+    const token = localStorage.getItem('accessToken');
+    if (!token) {
+      alert('로그인이 필요한 서비스입니다.');
+      navigate(-1);
+      return;
+    }
+
     const fetchProfileData = async () => {
       const [userRes, taskCountsRes, manualProjectRes, autoProjectRes] = await Promise.allSettled([
         apiClient.get('/user/me'),
@@ -59,7 +68,7 @@ const ProfilePage = () => {
       ]);
     };
     fetchProfileData();
-  }, []);
+  }, [navigate]);
 
   const handleImageClick = () => {
     if (isEditing) fileInputRef.current?.click();

--- a/FE/src/pages/ProjectPage/ProjectPage.jsx
+++ b/FE/src/pages/ProjectPage/ProjectPage.jsx
@@ -32,7 +32,7 @@ function ProjectPage() {
     const token = localStorage.getItem('accessToken');
     if (!token) {
       alert('로그인이 필요한 서비스입니다.');
-      navigate('/login');
+      navigate(-1);
       return;
     }
 

--- a/FE/src/pages/Teammaking/TeammakingPage.jsx
+++ b/FE/src/pages/Teammaking/TeammakingPage.jsx
@@ -1,4 +1,4 @@
-﻿﻿import { useState } from "react";
+﻿﻿import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import logoIcon from "../../assets/logoIcon.svg";
 import FormActions from "./components/FormActions.jsx";
@@ -26,6 +26,16 @@ const getTodayValue = () => {
 
 function TeammakingPage() {
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = localStorage.getItem('accessToken');
+    if (!token) {
+      alert('로그인이 필요한 서비스입니다.');
+      navigate(-1);
+      return;
+    }
+  }, [navigate]);
+
   const todayValue = getTodayValue();
   const [projectName, setProjectName] = useState("");
   const [selectedDomain, setSelectedDomain] = useState("PROJECT");


### PR DESCRIPTION
## 📌 개요
헤더 로그인 버튼 구현하였고, 비로그인 접근 제한을 추가했습니다.

## ⚙️ 작업 내용
- 비로그인 시 헤더 로그인 버튼 구현
- 비로그인 사용자 페이지 접근 제한 처리

### 헤더 로그인 버튼
<img width="2000" alt="image" src="https://github.com/user-attachments/assets/93c1139b-1080-42ec-a3e1-6bc8e87a79ed" />

### 호버효과
<img width="267" height="95" alt="image" src="https://github.com/user-attachments/assets/3daf363b-1f57-4e7e-82a8-dd3cd0950051" />

 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
