### PR TITLE
[feat] 팀장 프로필 조회 API 구현

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/project/repository/MemberRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/repository/MemberRepository.java
@@ -38,4 +38,10 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     boolean existsByProjectIdAndUserIdAndIsDeletedFalse(Long projectId, Long userId);
 
     int countByProjectId(Long projectId);
+
+    // 특정 사용자의 프로젝트 목록 조회 (프로젝트 상태 무관)
+    @Query("select m from Member m " +
+            "join fetch m.project " +
+            "where m.user.id = :userId")
+    List<Member> findByUserIdWithProject(@Param("userId") Long userId);
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/code/RecruitSuccessCode.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/code/RecruitSuccessCode.java
@@ -30,7 +30,8 @@ public enum RecruitSuccessCode implements BaseSuccessCode {
     APPLY_STATUS_UPDATED(HttpStatus.OK, "RECRUIT_S016", "지원서 상태 수정을 완료되었습니다."),
 
     RECRUITMENT_COMPLETED(HttpStatus.OK,"RECRUIT_S017", "모집이 완료되었으며, 프로젝트 팀이 생성되었습니다."),
-    RECRUITMENT_CREATED_LIST_FETCHED(HttpStatus.OK,"RECRUIT_S018", "내가 생성한 모집글 리스트 불러오기를 성공했습니다.")
+    RECRUITMENT_CREATED_LIST_FETCHED(HttpStatus.OK,"RECRUIT_S018", "내가 생성한 모집글 리스트 불러오기를 성공했습니다."),
+    RECRUIT_LEADER_PROFILE_FOUND(HttpStatus.OK, "RECRUIT_S019", "팀장 프로필 조회에 성공했습니다.")
     ;
 
     private final HttpStatus status;

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/controller/RecruitController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/controller/RecruitController.java
@@ -133,4 +133,14 @@ public class RecruitController {
 
         return ApiResponse.onSuccess(RecruitSuccessCode.RECRUITMENT_BOOKMARKED_LIST_FETCHED,response);
     }
+
+    @GetMapping("/{recruitmentId}/leader-profile")
+    public ApiResponse<RecruitLeaderProfileResponse> getRecruitLeaderProfile(
+            @PathVariable Long recruitmentId
+    ) {
+        return ApiResponse.onSuccess(
+                RecruitSuccessCode.RECRUIT_LEADER_PROFILE_FOUND,
+                recruitService.getRecruitLeaderProfile(recruitmentId)
+        );
+    }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitLeaderProfileResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitLeaderProfileResponse.java
@@ -1,0 +1,43 @@
+package org.example.promate.domain.recruit.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.promate.domain.project.enums.ProjectStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class RecruitLeaderProfileResponse {
+
+    private Long leaderId;
+    private String leaderName;
+    private String profileImageUrl;
+
+    private Double averageReviewScore;
+    private Long reviewCount;
+
+    private Integer completedTaskCount;
+    private Integer incompleteTaskCount;
+
+    private List<ProjectHistoryDTO> projects;
+
+    @Getter
+    @Builder
+    public static class ProjectHistoryDTO {
+        private Long projectId;
+        private String projectTitle;
+        private String role;
+        private String position;
+        private ProjectStatus projectStatus;
+        private LocalDate startDate;
+        private LocalDate endDate;
+
+        private Double averageReviewScore;
+        private Long reviewCount;
+
+        private Integer completedTaskCount;
+        private Integer incompleteTaskCount;
+    }
+}

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
@@ -19,10 +19,14 @@ import org.example.promate.domain.recruit.entity.Recruit;
 import org.example.promate.domain.recruit.enums.RecruitStatus;
 import org.example.promate.domain.recruit.repository.BookmarkRepository;
 import org.example.promate.domain.recruit.repository.RecruitRepository;
+import org.example.promate.domain.review.entity.MemberReview;
+import org.example.promate.domain.review.repository.MemberReviewRepository;
 import org.example.promate.domain.user.entity.User;
 import org.example.promate.domain.user.exception.UserErrorCode;
 import org.example.promate.domain.user.repository.UserRepository;
 import org.example.promate.domain.recruit.code.RecruitErrorCode;
+import org.example.promate.domain.workspace.enums.TaskStatus;
+import org.example.promate.domain.workspace.repository.TaskRepository;
 import org.example.promate.global.ApiPayload.exception.GeneralException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -45,6 +49,8 @@ public class RecruitService {
     private final ProjectRepository projectRepository;
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final MemberReviewRepository memberReviewRepository;
+    private final TaskRepository taskRepository;
 
     @Transactional
     public RecruitCreateResponse createRecruitment(
@@ -313,5 +319,92 @@ public class RecruitService {
         Page<MyRecruitResponse> mappedPage = recruitPage.map(MyRecruitResponse::from);
 
         return RecruitPageResponse.of(mappedPage);
+    }
+
+    public RecruitLeaderProfileResponse getRecruitLeaderProfile(Long recruitmentId) {
+
+        Recruit recruit = recruitRepository.findByIdAndIsDeletedFalse(recruitmentId)
+                .orElseThrow(() -> new GeneralException(RecruitErrorCode.RECRUITMENT_NOT_FOUND));
+
+        User leader = recruit.getUser();
+        Long leaderId = leader.getId();
+
+        List<Member> members = memberRepository.findByUserIdWithProject(leaderId);
+
+        List<RecruitLeaderProfileResponse.ProjectHistoryDTO> projects = members.stream()
+                .map(member -> {
+                    Project project = member.getProject();
+
+                    List<MemberReview> reviews =
+                            memberReviewRepository.findByProjectIdAndRevieweeId(
+                                    project.getId(),
+                                    leaderId
+                            );
+
+                    double averageReviewScore = reviews.stream()
+                            .mapToDouble(review ->
+                                    (review.getCommunicationScore()
+                                            + review.getProactivenessScore()
+                                            + review.getResponsibilityScore()
+                                            + review.getProblemSolvingScore()) / 4.0
+                            )
+                            .average()
+                            .orElse(0.0);
+
+                    int completedTaskCount =
+                            taskRepository.countByProjectIdAndMemberIdAndStatus(
+                                    project.getId(),
+                                    member.getId(),
+                                    TaskStatus.DONE
+                            );
+
+                    int incompleteTaskCount =
+                            taskRepository.countByProjectIdAndMemberIdAndStatusIn(
+                                    project.getId(),
+                                    member.getId(),
+                                    List.of(TaskStatus.TODO, TaskStatus.IN_PROGRESS)
+                            );
+
+                    return RecruitLeaderProfileResponse.ProjectHistoryDTO.builder()
+                            .projectId(project.getId())
+                            .projectTitle(project.getTitle())
+                            .role(member.getRole())
+                            .position(member.getPosition().name())
+                            .projectStatus(project.getStatus())
+                            .startDate(project.getStartDate())
+                            .endDate(project.getEndDate())
+                            .averageReviewScore(averageReviewScore)
+                            .reviewCount((long) reviews.size())
+                            .completedTaskCount(completedTaskCount)
+                            .incompleteTaskCount(incompleteTaskCount)
+                            .build();
+                })
+                .toList();
+
+        Double totalAverageReviewScore =
+                memberReviewRepository.getGlobalAverageScoreByUserId(leaderId);
+
+        int totalCompletedTaskCount = projects.stream()
+                .mapToInt(RecruitLeaderProfileResponse.ProjectHistoryDTO::getCompletedTaskCount)
+                .sum();
+
+        int totalIncompleteTaskCount = projects.stream()
+                .mapToInt(RecruitLeaderProfileResponse.ProjectHistoryDTO::getIncompleteTaskCount)
+                .sum();
+
+        long totalReviewCount = projects.stream()
+                .mapToLong(RecruitLeaderProfileResponse.ProjectHistoryDTO::getReviewCount)
+                .sum();
+
+        return RecruitLeaderProfileResponse.builder()
+                .leaderId(leader.getId())
+                .leaderName(leader.getName())
+                .profileImageUrl(leader.getProfileImageUrl())
+                .averageReviewScore(totalAverageReviewScore != null ? totalAverageReviewScore : 0.0)
+                .reviewCount(totalReviewCount)
+                .completedTaskCount(totalCompletedTaskCount)
+                .incompleteTaskCount(totalIncompleteTaskCount)
+                .projects(projects)
+                .build();
     }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/review/repository/MemberReviewRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/review/repository/MemberReviewRepository.java
@@ -25,4 +25,19 @@ public interface MemberReviewRepository extends JpaRepository<MemberReview, Long
     @Query("SELECT r.revieweeId, AVG((r.communicationScore + r.proactivenessScore + r.responsibilityScore + r.problemSolvingScore) / 4.0) " +
             "FROM MemberReview r WHERE r.revieweeId IN :userIds GROUP BY r.revieweeId")
     List<Object[]> findAverageScoresByUserIds(@Param("userIds") List<Long> userIds);
+
+
+    // 특정 사용자가 받은 전체 상호평가 개수 조회
+    Long countByRevieweeId(Long revieweeId);
+
+    // 특정 프로젝트에서 특정 사용자가 받은 평균 상호평가 점수 조회
+    @Query("SELECT AVG((r.communicationScore + r.proactivenessScore + r.responsibilityScore + r.problemSolvingScore) / 4.0) " +
+            "FROM MemberReview r " +
+            "WHERE r.revieweeId = :revieweeId " +
+            "AND r.projectId = :projectId")
+    Double findAverageScoreByRevieweeIdAndProjectId(
+            @Param("revieweeId") Long revieweeId,
+            @Param("projectId") Long projectId
+    );
+
 }


### PR DESCRIPTION
## 📌 개요
팀장 프로필 조회 API를 구현하였습니다.

## ⚙️ 작업 내용
- 모집글에서 모집글게시자(팀장)의 프로필과 프로젝트 이력을 조회하는 API를 구현하였습니다.

## 🎸 기타사항
