### PR TITLE
[feat] 프로젝트 설명 페이지 - 팀장 이력 조회 API 연동

### DIFF
--- a/FE/src/api/Recruits/recruitmentApi.js
+++ b/FE/src/api/Recruits/recruitmentApi.js
@@ -11,3 +11,18 @@ export const postApplication = async (recruitmentId, applicationData) => {
 
   return response.data;
 };
+
+/**
+ * 팀장 프로젝트 이력 조회
+ * @param {number|string} recruitmentId
+ * @returns {Promise<Object>}
+ */
+export const getLeaderProfile = async (recruitmentId) => {
+  try {
+    const response = await apiClient.get(`/recruits/${recruitmentId}/leader-profile`);
+    return response.data.data;
+  } catch (error) {
+    console.error("팀장 프로필 조회 실패:", error);
+    throw error;
+  }
+};

--- a/FE/src/api/Recruits/recruitmentApi.js
+++ b/FE/src/api/Recruits/recruitmentApi.js
@@ -11,18 +11,3 @@ export const postApplication = async (recruitmentId, applicationData) => {
 
   return response.data;
 };
-
-/**
- * 팀장 프로젝트 이력 조회
- * @param {number|string} recruitmentId
- * @returns {Promise<Object>}
- */
-export const getLeaderProfile = async (recruitmentId) => {
-  try {
-    const response = await apiClient.get(`/recruits/${recruitmentId}/leader-profile`);
-    return response.data.data;
-  } catch (error) {
-    console.error("팀장 프로필 조회 실패:", error);
-    throw error;
-  }
-};

--- a/FE/src/components/ProfileModal/ProfileModal.jsx
+++ b/FE/src/components/ProfileModal/ProfileModal.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import "./ProfileModal.css";
 import closeIcon from "../../assets/icons/closeIcon.svg";
 import ProfileAvatar from "../ProfileAvatar/ProfileAvatar";
-import { getLeaderProfile } from "../../api/Recruits/recruitmentApi.js";
 
 function ProfileModal({ isOpen, onClose, user, position }) {
   const [modalPos, setModalPos] = useState({ top: 0, left: 0 });

--- a/FE/src/components/ProfileModal/ProfileModal.jsx
+++ b/FE/src/components/ProfileModal/ProfileModal.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import "./ProfileModal.css";
 import closeIcon from "../../assets/icons/closeIcon.svg";
 import ProfileAvatar from "../ProfileAvatar/ProfileAvatar";
+import { getLeaderProfile } from "../../api/Recruits/recruitmentApi.js";
 
 function ProfileModal({ isOpen, onClose, user, position }) {
   const [modalPos, setModalPos] = useState({ top: 0, left: 0 });
@@ -42,7 +43,7 @@ function ProfileModal({ isOpen, onClose, user, position }) {
   }, [handleMouseMove]);
 
   const handleMouseDown = (e) => {
-    if (isMobile) return; // 모바일에서는 드래그 비활성화
+    if (isMobile) return;
     if (e.target.closest("button") || e.target.closest(".profile-project-list")) return;
 
     setIsDragging(true);
@@ -66,38 +67,7 @@ function ProfileModal({ isOpen, onClose, user, position }) {
 
   if (!isOpen) return null;
 
-  const projects = user?.projects ?? [
-    {
-      title: "동아리 프로젝트",
-      period: "2025 - 03 - 20 ~",
-      status: "진행중",
-      score: null,
-    },
-    {
-      title: "WAP 해커톤",
-      period: "2025 - 03 - 20 ~ 2025 - 07 - 20",
-      status: "완료",
-      score: "4.7",
-    },
-    {
-      title: "WAP 해커톤",
-      period: "2025 - 03 - 20 ~ 2025 - 07 - 20",
-      status: "완료",
-      score: "4.7",
-    },
-    {
-      title: "WAP 해커톤",
-      period: "2025 - 03 - 20 ~ 2025 - 07 - 20",
-      status: "완료",
-      score: "4.7",
-    },
-    {
-      title: "WAP 해커톤",
-      period: "2025 - 03 - 20 ~ 2025 - 07 - 20",
-      status: "완료",
-      score: "4.7",
-    },
-  ];
+  const projects = user?.projects ?? [];
 
   const popoverStyle = isMobile
     ? {
@@ -135,14 +105,14 @@ function ProfileModal({ isOpen, onClose, user, position }) {
 
         <div className="profile-popover-header">
           <div className="profile-user-info">
-            <ProfileAvatar src={user?.profileImage} alt="프로필 이미지" />
+            <ProfileAvatar src={user?.profileImage || user?.profileImageUrl} alt="프로필 이미지" />
 
-            <strong className="profile-name">{user?.name || "김아무개"}</strong>
+            <strong className="profile-name">{user?.name || user?.leaderName || "김아무개"}</strong>
           </div>
 
           <div className="profile-task-count">
-            <span className="completed-task">{user?.completedTaskCount ?? 3}</span>
-            <span className="total-task">/{user?.totalTaskCount ?? 4}</span>
+            <span className="completed-task">{user?.completedTaskCount ?? 0}</span>
+            <span className="total-task">/{user?.totalTaskCount ?? ((user?.completedTaskCount || 0) + (user?.incompleteTaskCount || 0))}</span>
           </div>
         </div>
 
@@ -150,35 +120,42 @@ function ProfileModal({ isOpen, onClose, user, position }) {
           <h3 className="profile-section-title">프로젝트 경험</h3>
 
           <div className="profile-project-list">
-            {projects.map((project, index) => (
-              <div className="profile-project-item" key={index}>
-                <div className="project-main-info">
-                  <span className="project-title">{project.title}</span>
-                  <span className="project-period">{project.period}</span>
-                </div>
+            {projects.map((project, index) => {
+              const title = project.title || project.projectTitle;
+              const period = project.period || (project.startDate && project.endDate ? `${project.startDate} ~ ${project.endDate}` : "");
+              const status = project.status || (project.projectStatus === "DONE" ? "완료" : "진행중");
+              const score = project.score || project.averageReviewScore;
 
-                <div className="project-sub-info">
-                  <span
-                    className={`project-status ${
-                      project.status === "진행중" ? "active" : "done"
-                    }`}
-                  >
-                    {project.status}
-                  </span>
+              return (
+                <div className="profile-project-item" key={index}>
+                  <div className="project-main-info">
+                    <span className="project-title">{title}</span>
+                    <span className="project-period">{period}</span>
+                  </div>
 
-                  <div className="project-score">
-                    {project.score ? (
-                      <>
-                        <span className="score-number">{project.score}</span>
-                        <span className="score-text">점</span>
-                      </>
-                    ) : (
-                      <span className="empty-score"></span>
-                    )}
+                  <div className="project-sub-info">
+                    <span
+                      className={`project-status ${
+                        status === "진행중" ? "active" : "done"
+                      }`}
+                    >
+                      {status}
+                    </span>
+
+                    <div className="project-score">
+                      {score ? (
+                        <>
+                          <span className="score-number">{score}</span>
+                          <span className="score-text">점</span>
+                        </>
+                      ) : (
+                        <span className="empty-score"></span>
+                      )}
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       </div>

--- a/FE/src/pages/ProjectReadMePage/ProjectReadMePage.jsx
+++ b/FE/src/pages/ProjectReadMePage/ProjectReadMePage.jsx
@@ -62,15 +62,24 @@ function ProjectReadMePage() {
     else setIsLoading(false);
   }, [postId]);
 
-  const handleMemberClick = (user, event) => {
+  const handleMemberClick = async (event) => {
     const rect = event.currentTarget.getBoundingClientRect();
     setModalPosition({
       top: rect.top,
       left: rect.left,
       width: rect.width
     });
-    setSelectedUser(user);
-    setIsProfileModalOpen(true);
+
+    try {
+      const response = await apiClient.get(`/recruits/${postId}/leader-profile`);
+      if (response.data && response.data.isSuccess) {
+        setSelectedUser(response.data.data);
+        setIsProfileModalOpen(true);
+      }
+    } catch (error) {
+      console.error('팀장 프로필 조회 실패:', error);
+      alert('팀장 프로필 정보를 불러오는데 실패했습니다.');
+    }
   };
 
   const handleApplyClick = () => {
@@ -160,7 +169,7 @@ function ProjectReadMePage() {
             <div className="project-readme-team-role">팀장</div>
             <div 
               className="project-readme-team-member-name clickable" 
-              onClick={(e) => handleMemberClick({ name: projectData.author?.nickname, profileImage: projectData.author?.profileImageUrl }, e)}
+              onClick={handleMemberClick}
             >
               {projectData.author?.nickname || "알 수 없음"}
             </div>

--- a/FE/src/pages/ProjectReadMePage/ProjectReadMePage.jsx
+++ b/FE/src/pages/ProjectReadMePage/ProjectReadMePage.jsx
@@ -71,7 +71,7 @@ function ProjectReadMePage() {
     });
 
     try {
-      const response = await apiClient.get(`/recruits/${postId}/leader-profile`);
+      const response = await apiClient.get(`/recruitments/${postId}/leader-profile`);
       if (response.data && response.data.isSuccess) {
         setSelectedUser(response.data.data);
         setIsProfileModalOpen(true);


### PR DESCRIPTION
## 📌 개요
프로젝트 설명 페이지에서 프로필 모달에 팀장 이력 조회 API 연동했습니다.

## ⚙️ 작업 내용
- 팀장 이력 조회 api 연동
- 목업 데이터 제거
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
