### PR TITLE
[feat] 팀 페이지 - 일정 관리 모달 구현 및 API 연동

### DIFF
--- a/FE/src/components/AddEventModal/AddEventModal.css
+++ b/FE/src/components/AddEventModal/AddEventModal.css
@@ -1,4 +1,4 @@
-.modal-overlay {
+.aem-overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -11,7 +11,7 @@
   z-index: 9999;
 }
 
-.add-event-modal {
+.aem-container {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -26,7 +26,7 @@
   box-sizing: border-box;
 }
 
-.modal-content {
+.aem-content {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -35,7 +35,7 @@
   width: 100%;
 }
 
-.modal-title {
+.aem-title {
   width: 100%;
   height: 24px;
   font-family: 'Pretendard', sans-serif;
@@ -47,7 +47,7 @@
   margin: 0;
 }
 
-.input-group {
+.aem-input-group {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -56,16 +56,17 @@
   width: 100%;
 }
 
-.input-label {
+.aem-input-label {
   font-family: 'Pretendard', sans-serif;
   font-style: normal;
   font-weight: 600;
   font-size: 18px;
   line-height: 21px;
   color: #000000;
+  margin-left: 3px;
 }
 
-.title-input {
+.aem-input-field {
   box-sizing: border-box;
   width: 100%;
   height: 33px;
@@ -81,16 +82,24 @@
   color: #000000;
 }
 
-.title-input::placeholder {
+.aem-input-field::placeholder {
   color: #ABABAB;
 }
 
-.title-input:focus {
+.aem-input-field:focus {
   outline: none;
   border-color: #FE9A57;
 }
 
-.date-group {
+.aem-content-field {
+  resize: none;
+  height: 80px;
+  padding-top: 10px;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.aem-date-group {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -99,7 +108,7 @@
   width: 100%;
 }
 
-.date-row {
+.aem-date-row {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -109,7 +118,7 @@
   height: 33px;
 }
 
-.row-label {
+.aem-row-label {
   width: 56px;
   font-family: 'Pretendard', sans-serif;
   font-style: normal;
@@ -121,17 +130,17 @@
   box-sizing: border-box;
 }
 
-.custom-date-picker {
+.aem-date-picker {
   position: relative;
-  width: 200px;
+  flex-grow: 1;
   height: 33px;
-  flex-grow: 0;
 }
 
-.date-display {
+.aem-date-display {
   width: 100%;
   height: 100%;
-  background: #FFFFFF;
+  background: #F1F1F1;
+  border: 1px solid #ABABAB;
   border-radius: 5px;
   font-family: 'Pretendard', sans-serif;
   font-weight: 400;
@@ -143,7 +152,7 @@
   box-sizing: border-box;
 }
 
-.hidden-date-input {
+.aem-hidden-input {
   position: absolute;
   top: 0;
   left: 0;
@@ -153,7 +162,7 @@
   cursor: pointer;
 }
 
-.hidden-date-input::-webkit-calendar-picker-indicator {
+.aem-hidden-input::-webkit-calendar-picker-indicator {
   position: absolute;
   top: 0;
   left: 0;
@@ -162,79 +171,11 @@
   cursor: pointer;
 }
 
-.time-input {
-  width: 64px;
-  height: 33px;
-  background: #FFFFFF;
-  border: none;
-  border-radius: 5px;
-  font-family: 'Pretendard', sans-serif;
-  font-weight: 400;
-  font-size: 16px;
-  color: #000000;
-  box-sizing: border-box;
-  padding: 0;
-  text-align: center;
-  appearance: none;
-  cursor: pointer;
-}
-
-.custom-date-picker:focus-within .date-display, 
-.time-input:focus {
+.aem-date-picker:focus-within .aem-date-display {
   outline: 1px solid #FE9A57;
 }
 
-.all-day-row {
-  position: relative;
-}
-
-/* Switch Styles */
-.switch {
-  position: absolute;
-  right: 0;
-  width: 52px;
-  height: 32px;
-}
-
-.switch input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: #D9D9D9;
-  transition: .4s;
-  border-radius: 100px;
-}
-
-.slider:before {
-  position: absolute;
-  content: "";
-  height: 24px;
-  width: 24px;
-  left: 4px;
-  bottom: 4px;
-  background-color: white;
-  transition: .4s;
-  border-radius: 50%;
-}
-
-input:checked + .slider {
-  background-color: #FE9A57;
-}
-
-input:checked + .slider:before {
-  transform: translateX(20px);
-}
-
-.modal-actions {
+.aem-actions {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
@@ -245,7 +186,7 @@ input:checked + .slider:before {
   margin-top: 10px;
 }
 
-.cancel-btn {
+.aem-cancel-btn {
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -264,7 +205,7 @@ input:checked + .slider:before {
   cursor: pointer;
 }
 
-.add-btn {
+.aem-submit-btn {
   display: flex;
   flex-direction: row;
   justify-content: center;

--- a/FE/src/components/AddEventModal/AddEventModal.jsx
+++ b/FE/src/components/AddEventModal/AddEventModal.jsx
@@ -2,13 +2,6 @@ import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import './AddEventModal.css';
 
-const timeOptions = [];
-for (let i = 0; i < 24; i++) {
-  const hour = String(i).padStart(2, '0');
-  timeOptions.push(`${hour}:00`);
-  timeOptions.push(`${hour}:30`);
-}
-
 const getTodayString = () => {
   const today = new Date();
   const year = today.getFullYear();
@@ -20,11 +13,10 @@ const getTodayString = () => {
 
 function AddEventModal({ isOpen, onClose, onAddEvent }) {
   const [title, setTitle] = useState('');
-  const [isAllDay, setIsAllDay] = useState(false);
+  const [content, setContent] = useState('');
   const [startDate, setStartDate] = useState(getTodayString());
   const [endDate, setEndDate] = useState(getTodayString());
-  const [startTime, setStartTime] = useState('12:00');
-  const [endTime, setEndTime] = useState('13:00');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const formatDateWithDay = (dateString) => {
     const [year, month, day] = dateString.split('-').map(Number);
@@ -40,36 +32,41 @@ function AddEventModal({ isOpen, onClose, onAddEvent }) {
 
   const handleClose = () => {
     setTitle('');
-    setIsAllDay(false);
+    setContent('');
     setStartDate(getTodayString());
     setEndDate(getTodayString());
-    setStartTime('12:00');
-    setEndTime('13:00');
     onClose();
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!title.trim()) {
       alert('제목을 입력해주세요.');
       return;
     }
 
-    const start = new Date(`${startDate}T${isAllDay ? '00:00' : startTime}`);
-    const end = new Date(`${endDate}T${isAllDay ? '23:59' : endTime}`);
+    const start = new Date(startDate);
+    const end = new Date(endDate);
 
     if (start > end) {
-      alert('종료 시간이 시작 시간보다 빠를 수 없습니다.');
+      alert('종료일이 시작일보다 빠를 수 없습니다.');
       return;
     }
 
-    onAddEvent({
-      text: title.trim(),
-      start,
-      end,
-      isAllDay,
-    });
+    try {
+      setIsSubmitting(true);
+      const success = await onAddEvent({
+        title: title.trim(),
+        content: content.trim(),
+        startDate,
+        endDate,
+      });
 
-    handleClose();
+      if (success !== false) {
+        handleClose();
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   if (!isOpen) {
@@ -77,102 +74,72 @@ function AddEventModal({ isOpen, onClose, onAddEvent }) {
   }
 
   return ReactDOM.createPortal(
-    <div className="modal-overlay" onClick={handleClose}>
-      <div className="add-event-modal" onClick={(e) => e.stopPropagation()}>
-        <div className="modal-content">
-          <h2 className="modal-title">새 일정</h2>
+    <div className="aem-overlay" onClick={handleClose}>
+      <div className="aem-container" onClick={(e) => e.stopPropagation()}>
+        <div className="aem-content">
+          <h2 className="aem-title">새 일정</h2>
 
-          <div className="input-group">
-            <label className="input-label">제목</label>
+          <div className="aem-input-group">
+            <label className="aem-input-label">제목</label>
             <input
               type="text"
-              className="title-input"
+              className="aem-input-field"
               placeholder="제목을 적어주세요."
               value={title}
               onChange={(e) => setTitle(e.target.value)}
             />
           </div>
 
-          <div className="date-group">
-            <label className="input-label">날짜</label>
+          <div className="aem-input-group aem-content-group">
+            <label className="aem-input-label">내용</label>
+            <textarea
+              className="aem-input-field aem-content-field"
+              placeholder="내용을 적어주세요."
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+            />
+          </div>
 
-            <div className="date-row">
-              <span className="row-label">시작</span>
-              <div className="custom-date-picker">
-                <div className="date-display">
+          <div className="aem-date-group">
+            <label className="aem-input-label">날짜</label>
+
+            <div className="aem-date-row">
+              <span className="aem-row-label">시작</span>
+              <div className="aem-date-picker">
+                <div className="aem-date-display">
                   {formatDateWithDay(startDate)}
                 </div>
                 <input
                   type="date"
-                  className="hidden-date-input"
+                  className="aem-hidden-input"
                   value={startDate}
                   onChange={(e) => setStartDate(e.target.value)}
                 />
               </div>
-
-              {!isAllDay && (
-                <select
-                  className="time-input"
-                  value={startTime}
-                  onChange={(e) => setStartTime(e.target.value)}
-                >
-                  {timeOptions.map((time) => (
-                    <option key={time} value={time}>
-                      {time}
-                    </option>
-                  ))}
-                </select>
-              )}
             </div>
 
-            <div className="date-row">
-              <span className="row-label">종료</span>
-              <div className="custom-date-picker">
-                <div className="date-display">
+            <div className="aem-date-row">
+              <span className="aem-row-label">종료</span>
+              <div className="aem-date-picker">
+                <div className="aem-date-display">
                   {formatDateWithDay(endDate)}
                 </div>
                 <input
                   type="date"
-                  className="hidden-date-input"
+                  className="aem-hidden-input"
                   value={endDate}
                   onChange={(e) => setEndDate(e.target.value)}
                 />
               </div>
-
-              {!isAllDay && (
-                <select
-                  className="time-input"
-                  value={endTime}
-                  onChange={(e) => setEndTime(e.target.value)}
-                >
-                  {timeOptions.map((time) => (
-                    <option key={time} value={time}>
-                      {time}
-                    </option>
-                  ))}
-                </select>
-              )}
-            </div>
-
-            <div className="date-row all-day-row">
-              <span className="row-label">종일</span>
-              <label className="switch">
-                <input
-                  type="checkbox"
-                  checked={isAllDay}
-                  onChange={(e) => setIsAllDay(e.target.checked)}
-                />
-                <span className="slider"></span>
-              </label>
             </div>
           </div>
 
-          <div className="modal-actions">
-            <button type="button" className="cancel-btn" onClick={handleClose}>
+          <div className="aem-actions">
+            <button type="button" className="aem-cancel-btn" onClick={handleClose} disabled={isSubmitting}>
               취소
             </button>
-            <button type="button" className="add-btn" onClick={handleSubmit}>
-              일정 추가
+            <button type="button" className="aem-submit-btn" onClick={handleSubmit} disabled={isSubmitting}>
+              {isSubmitting ? '추가 중...' : '일정 추가'}
             </button>
           </div>
         </div>

--- a/FE/src/components/Calendar/Calendar.jsx
+++ b/FE/src/components/Calendar/Calendar.jsx
@@ -100,13 +100,30 @@ function Calendar({ showAddButton = true, projectId }) {
     setIsModalOpen(false);
   };
 
-  const handleAddEvent = (newEventData) => {
-    const newEvent = {
-      id: Date.now(),
-      ...newEventData,
-      checked: false,
-    };
-    setEvents((prevEvents) => [...prevEvents, newEvent]);
+  const handleAddEvent = async (newEventData) => {
+    if (!projectId) return false;
+
+    try {
+      const response = await apiClient.post(`/projects/${projectId}/schedules`, newEventData);
+      const created = response.data.data;
+      
+      const [startYear, startMonth, startDay] = created.startDate.split('-').map(Number);
+      const [endYear, endMonth, endDay] = created.endDate.split('-').map(Number);
+      
+      const newEvent = {
+        id: created.scheduleId,
+        text: created.title,
+        start: new Date(startYear, startMonth - 1, startDay),
+        end: new Date(endYear, endMonth - 1, endDay),
+        checked: false,
+      };
+      setEvents((prevEvents) => [...prevEvents, newEvent]);
+      return true;
+    } catch (error) {
+      console.error('일정 추가 실패:', error);
+      alert(error.message || '일정 추가에 실패했습니다.');
+      return false;
+    }
   };
 
   return (

--- a/FE/src/components/Calendar/Calendar.jsx
+++ b/FE/src/components/Calendar/Calendar.jsx
@@ -3,15 +3,17 @@ import './Calendar.css';
 import calendarIcon from '../../assets/CalendarIcon.svg';
 import plusIcon from '../../assets/icons/plusIcon.svg';
 import AddEventModal from '../AddEventModal/AddEventModal';
+import EventDetailModal from '../EventDetailModal/EventDetailModal';
 import apiClient from '../../api/apiClient';
 
 const WEEKDAYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 
-function Calendar({ showAddButton = true, projectId }) {
+function Calendar({ showAddButton = true, projectId, projectTitle: fallbackProjectTitle }) {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [events, setEvents] = useState([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [hasError, setHasError] = useState(false);
+  const [selectedEvent, setSelectedEvent] = useState(null);
 
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
@@ -61,7 +63,7 @@ function Calendar({ showAddButton = true, projectId }) {
             end: new Date(endYear, endMonth - 1, endDay),
             checked: false,
             projectId: item.projectId,
-            projectTitle: item.projectTitle,
+            projectTitle: item.projectTitle || fallbackProjectTitle,
             content: item.content,
           };
         }).filter(Boolean);
@@ -255,9 +257,14 @@ function Calendar({ showAddButton = true, projectId }) {
                                 width: `calc(${eventSpan * 100}% + ${
                                   eventSpan - 1
                                 }px)`,
+                                cursor: 'pointer',
                               }
-                            : undefined
+                            : { cursor: 'pointer' }
                         }
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedEvent(event);
+                        }}
                       >
                         {isSegmentStart ? event.text : ''}
                       </div>
@@ -274,6 +281,11 @@ function Calendar({ showAddButton = true, projectId }) {
         isOpen={isModalOpen}
         onClose={handleCloseModal}
         onAddEvent={handleAddEvent}
+      />
+
+      <EventDetailModal
+        event={selectedEvent}
+        onClose={() => setSelectedEvent(null)}
       />
     </section>
   );

--- a/FE/src/components/Calendar/Calendar.jsx
+++ b/FE/src/components/Calendar/Calendar.jsx
@@ -7,34 +7,71 @@ import apiClient from '../../api/apiClient';
 
 const WEEKDAYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 
-function Calendar({ showAddButton = true }) {
+function Calendar({ showAddButton = true, projectId }) {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [events, setEvents] = useState([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [hasError, setHasError] = useState(false);
 
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+
   useEffect(() => {
     const fetchEvents = async () => {
       try {
         setHasError(false);
-        const response = await apiClient.get('/dashboard/calendar');
-        const fetchedEvents = (response.data.data || []).map((item) => {
-          const startAt = item.startAt || '';
-          const endAt = item.endAt || '';
-          const [startYear, startMonth, startDay] = startAt.split('-').map(Number);
-          const [endYear, endMonth, endDay] = endAt.split('-').map(Number);
+        let fetchedEvents = [];
+        
+        if (projectId) {
+          const response = await apiClient.get(`/projects/${projectId}/schedules`, {
+            params: {
+              year,
+              month: month + 1,
+            },
+          });
           
-          return {
-            id: item.scheduleId,
-            text: item.title,
-            start: new Date(startYear, startMonth - 1, startDay),
-            end: new Date(endYear, endMonth - 1, endDay),
-            checked: false,
-            projectId: item.projectId,
-            projectTitle: item.projectTitle,
-            content: item.content,
-          };
-        });
+          const responseData = response.data?.data;
+          const eventList = Array.isArray(responseData) ? responseData : (responseData?.scheduleList || []);
+          
+          fetchedEvents = eventList.map((item) => {
+            const startDate = item.startDate || '';
+            const endDate = item.endDate || '';
+            const [startYear, startMonth, startDay] = startDate.split('-').map(Number);
+            const [endYear, endMonth, endDay] = endDate.split('-').map(Number);
+            
+            return {
+              id: item.scheduleId,
+              text: item.title,
+              start: new Date(startYear, startMonth - 1, startDay),
+              end: new Date(endYear, endMonth - 1, endDay),
+              checked: false,
+            };
+          });
+        } else {
+          const response = await apiClient.get('/dashboard/calendar');
+          
+          const responseData = response.data?.data;
+          const eventList = Array.isArray(responseData) ? responseData : (responseData?.scheduleList || []);
+
+          fetchedEvents = eventList.map((item) => {
+            const startAt = item.startAt || '';
+            const endAt = item.endAt || '';
+            const [startYear, startMonth, startDay] = startAt.split('-').map(Number);
+            const [endYear, endMonth, endDay] = endAt.split('-').map(Number);
+            
+            return {
+              id: item.scheduleId,
+              text: item.title,
+              start: new Date(startYear, startMonth - 1, startDay),
+              end: new Date(endYear, endMonth - 1, endDay),
+              checked: false,
+              projectId: item.projectId,
+              projectTitle: item.projectTitle,
+              content: item.content,
+            };
+          });
+        }
+
         setEvents(fetchedEvents);
       } catch (error) {
         console.error('캘린더 일정 조회 실패:', error);
@@ -43,10 +80,7 @@ function Calendar({ showAddButton = true }) {
     };
 
     fetchEvents();
-  }, []);
-
-  const year = currentDate.getFullYear();
-  const month = currentDate.getMonth();
+  }, [projectId, year, month]);
 
   const days = useMemo(() => getCalendarDays(year, month), [year, month]);
 
@@ -201,7 +235,6 @@ function Calendar({ showAddButton = true }) {
                         style={
                           isSegmentStart
                             ? {
-                                // 이어지는 일정은 시작 칸에서만 너비를 확장
                                 width: `calc(${eventSpan * 100}% + ${
                                   eventSpan - 1
                                 }px)`,
@@ -244,7 +277,6 @@ function getCalendarDays(year, month) {
     return days;
   }
 
-  // 마지막 주도 7칸 구조를 유지하도록 빈 칸을 추가
   return [...days, ...Array(7 - remainder).fill(null)];
 }
 
@@ -279,7 +311,6 @@ function getEventsByDay(events, year, month, day) {
 function isEventSegmentStart(event, year, month, day, index) {
   const currentDate = new Date(year, month, day).getTime();
 
-  // 일정 시작일이 아니어도 월 첫날이나 주 첫날이면 새 구간으로 다시 표시
   return (
     currentDate === event.start.getTime() ||
     day === 1 ||
@@ -308,7 +339,6 @@ function getEventSpan(event, year, month, day, index) {
 
   const remainingEventDays = eventEndDay - day + 1;
 
-  // 일정이 현재 주 안에서 차지할 칸 수만 계산
   return Math.min(daysUntilWeekEnd, remainingEventDays);
 }
 

--- a/FE/src/components/Calendar/Calendar.jsx
+++ b/FE/src/components/Calendar/Calendar.jsx
@@ -20,57 +20,51 @@ function Calendar({ showAddButton = true, projectId }) {
     const fetchEvents = async () => {
       try {
         setHasError(false);
-        let fetchedEvents = [];
+        let response;
         
         if (projectId) {
-          const response = await apiClient.get(`/projects/${projectId}/schedules`, {
-            params: {
-              year,
-              month: month + 1,
-            },
-          });
-          
-          const responseData = response.data?.data;
-          const eventList = Array.isArray(responseData) ? responseData : (responseData?.scheduleList || []);
-          
-          fetchedEvents = eventList.map((item) => {
-            const startDate = item.startDate || '';
-            const endDate = item.endDate || '';
-            const [startYear, startMonth, startDay] = startDate.split('-').map(Number);
-            const [endYear, endMonth, endDay] = endDate.split('-').map(Number);
-            
-            return {
-              id: item.scheduleId,
-              text: item.title,
-              start: new Date(startYear, startMonth - 1, startDay),
-              end: new Date(endYear, endMonth - 1, endDay),
-              checked: false,
-            };
+          response = await apiClient.get(`/projects/${projectId}/schedules`, {
+            params: { year, month: month + 1, _t: new Date().getTime() },
           });
         } else {
-          const response = await apiClient.get('/dashboard/calendar');
-          
-          const responseData = response.data?.data;
-          const eventList = Array.isArray(responseData) ? responseData : (responseData?.scheduleList || []);
-
-          fetchedEvents = eventList.map((item) => {
-            const startAt = item.startAt || '';
-            const endAt = item.endAt || '';
-            const [startYear, startMonth, startDay] = startAt.split('-').map(Number);
-            const [endYear, endMonth, endDay] = endAt.split('-').map(Number);
-            
-            return {
-              id: item.scheduleId,
-              text: item.title,
-              start: new Date(startYear, startMonth - 1, startDay),
-              end: new Date(endYear, endMonth - 1, endDay),
-              checked: false,
-              projectId: item.projectId,
-              projectTitle: item.projectTitle,
-              content: item.content,
-            };
+          response = await apiClient.get('/dashboard/calendar', {
+            params: { _t: new Date().getTime() }
           });
         }
+
+        const responseData = response.data?.data || response.data;
+        let eventList = [];
+        if (Array.isArray(responseData)) {
+          eventList = responseData;
+        } else if (responseData && typeof responseData === 'object') {
+          const arrays = Object.values(responseData).filter(Array.isArray);
+          eventList = arrays.length > 0 ? arrays[0] : [];
+        }
+
+        const fetchedEvents = eventList.map((item, index) => {
+          const startDateStr = item.startDate || item.startAt || item.start_date || item.date;
+          if (!startDateStr) return null;
+          const endDateStr = item.endDate || item.endAt || item.end_date || startDateStr;
+
+          const cleanStart = String(startDateStr).split('T')[0].replace(/\./g, '-');
+          const cleanEnd = String(endDateStr).split('T')[0].replace(/\./g, '-');
+
+          const [startYear, startMonth, startDay] = cleanStart.split('-').map(Number);
+          const [endYear, endMonth, endDay] = cleanEnd.split('-').map(Number);
+
+          if (isNaN(startYear) || isNaN(startMonth) || isNaN(startDay)) return null;
+          
+          return {
+            id: item.scheduleId || item.id || item.taskId || index,
+            text: item.title || item.name || item.content || '(제목 없음)',
+            start: new Date(startYear, startMonth - 1, startDay),
+            end: new Date(endYear, endMonth - 1, endDay),
+            checked: false,
+            projectId: item.projectId,
+            projectTitle: item.projectTitle,
+            content: item.content,
+          };
+        }).filter(Boolean);
 
         setEvents(fetchedEvents);
       } catch (error) {
@@ -107,8 +101,14 @@ function Calendar({ showAddButton = true, projectId }) {
       const response = await apiClient.post(`/projects/${projectId}/schedules`, newEventData);
       const created = response.data.data;
       
-      const [startYear, startMonth, startDay] = created.startDate.split('-').map(Number);
-      const [endYear, endMonth, endDay] = created.endDate.split('-').map(Number);
+      const startDateStr = created.startDate || created.startAt || newEventData.startDate;
+      const endDateStr = created.endDate || created.endAt || newEventData.endDate;
+
+      const cleanStart = startDateStr.split('T')[0].replace(/\./g, '-');
+      const cleanEnd = endDateStr.split('T')[0].replace(/\./g, '-');
+
+      const [startYear, startMonth, startDay] = cleanStart.split('-').map(Number);
+      const [endYear, endMonth, endDay] = cleanEnd.split('-').map(Number);
       
       const newEvent = {
         id: created.scheduleId,
@@ -321,7 +321,7 @@ function getEventsByDay(events, year, month, day) {
         return startDiff;
       }
 
-      return a.id - b.id;
+      return String(a.id).localeCompare(String(b.id));
     });
 }
 

--- a/FE/src/components/EventDetailModal/EventDetailModal.css
+++ b/FE/src/components/EventDetailModal/EventDetailModal.css
@@ -28,16 +28,15 @@
 
 .edm-header {
   display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  align-items: center;
-  padding: 0px 20px;
   width: 100%;
   height: 40px;
   margin-top: 10px;
 }
 
 .edm-close-btn {
+  position: absolute;
+  top: 18px;
+  right: 24px;
   width: 24px;
   height: 24px;
   background: transparent;
@@ -148,8 +147,8 @@
     gap: 20px;
   }
 
-  .edm-header {
-    padding: 0px 4px;
+  .edm-close-btn {
+    right: 16px;
   }
 
   .edm-body {

--- a/FE/src/components/EventDetailModal/EventDetailModal.css
+++ b/FE/src/components/EventDetailModal/EventDetailModal.css
@@ -1,0 +1,180 @@
+.edm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.edm-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0px 60px 40px;
+  gap: 27px;
+  width: 700px;
+  min-width: 300px;
+  min-height: 461px;
+  background: #FFFFFF;
+  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.05);
+  border-radius: 10px;
+  position: relative;
+}
+
+.edm-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 0px 20px;
+  width: 100%;
+  height: 40px;
+  margin-top: 10px;
+}
+
+.edm-close-btn {
+  width: 24px;
+  height: 24px;
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  color: #909090;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+}
+
+.edm-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0px;
+  gap: 22px;
+  width: 100%;
+  max-width: 580px;
+}
+
+.edm-title {
+  width: 100%;
+  font-family: 'Pretendard', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 29px;
+  color: #000000;
+  margin: 0;
+}
+
+.edm-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0px;
+  gap: 10px;
+  width: 100%;
+}
+
+.edm-info-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 20px;
+}
+
+.edm-info-label {
+  min-width: 60px;
+}
+
+.edm-info-label,
+.edm-info-value {
+  font-family: 'Pretendard', sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 17px;
+  color: #909090;
+}
+
+.edm-project-link {
+  cursor: pointer;
+  text-decoration: underline;
+  transition: color 0.2s ease-in-out;
+}
+
+.edm-project-link:hover {
+  color: #000000;
+}
+
+.edm-divider {
+  width: 100%;
+  height: 1px;
+  background: #D9D9D9;
+  margin: 10px 0;
+}
+
+.edm-content-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0px;
+  gap: 10px;
+  width: 100%;
+  min-height: 250px;
+}
+
+.edm-content {
+  font-family: 'Pretendard', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  color: #000000;
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 768px) {
+  .edm-container {
+    width: calc(100% - 40px);
+    padding: 0px 24px 24px;
+    min-height: auto;
+    gap: 20px;
+  }
+
+  .edm-header {
+    padding: 0px 4px;
+  }
+
+  .edm-body {
+    max-width: 100%;
+    gap: 16px;
+  }
+
+  .edm-title {
+    font-size: 20px;
+    line-height: 24px;
+  }
+
+  .edm-info-row {
+    gap: 14px;
+  }
+
+  .edm-info-label {
+    min-width: 50px;
+  }
+
+  .edm-content-wrapper {
+    min-height: 150px;
+  }
+
+  .edm-content {
+    font-size: 13px;
+  }
+}

--- a/FE/src/components/EventDetailModal/EventDetailModal.jsx
+++ b/FE/src/components/EventDetailModal/EventDetailModal.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { useNavigate } from 'react-router-dom';
+import './EventDetailModal.css';
+
+function EventDetailModal({ event, onClose }) {
+  const navigate = useNavigate();
+
+  if (!event) return null;
+
+  const formatEventDate = (date) => {
+    if (!date) return '';
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+    const weekday = weekdays[date.getDay()];
+    
+    return `${year}.${month}.${day} (${weekday})`;
+  };
+
+  const dateString = `${formatEventDate(event.start)} ~ ${formatEventDate(event.end)}`;
+
+  const handleProjectClick = () => {
+    if (event.projectId) {
+      navigate(`/project/${event.projectId}`, { state: { projectTitle: event.projectTitle } });
+      onClose();
+    }
+  };
+
+  return ReactDOM.createPortal(
+    <div className="edm-overlay" onClick={onClose}>
+      <div className="edm-container" onClick={(e) => e.stopPropagation()}>
+        <div className="edm-header">
+          <button type="button" className="edm-close-btn" onClick={onClose} aria-label="닫기">
+            ✕
+          </button>
+        </div>
+        
+        <div className="edm-body">
+          <h2 className="edm-title">{event.text}</h2>
+          
+          <div className="edm-info">
+            {event.projectTitle && (
+              <div className="edm-info-row">
+                <span className="edm-info-label">프로젝트</span>
+                <span 
+                  className={`edm-info-value ${event.projectId ? 'edm-project-link' : ''}`}
+                  onClick={event.projectId ? handleProjectClick : undefined}
+                >
+                  {event.projectTitle}
+                </span>
+              </div>
+            )}
+            <div className="edm-info-row">
+              <span className="edm-info-label">날짜</span>
+              <span className="edm-info-value">{dateString}</span>
+            </div>
+            
+            <div className="edm-divider" />
+            
+            <div className="edm-content-wrapper">
+              <p className="edm-content">{event.content || '등록된 내용이 없습니다.'}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export default EventDetailModal;

--- a/FE/src/components/EventDetailModal/EventDetailModal.jsx
+++ b/FE/src/components/EventDetailModal/EventDetailModal.jsx
@@ -1,12 +1,47 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { useNavigate } from 'react-router-dom';
+import apiClient from '../../api/apiClient';
 import './EventDetailModal.css';
 
 function EventDetailModal({ event, onClose }) {
   const navigate = useNavigate();
+  const [detailData, setDetailData] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
 
-  if (!event) return null;
+  useEffect(() => {
+    if (!event) {
+      setDetailData(null);
+      return;
+    }
+
+    setDetailData(event);
+
+    const fetchEventDetail = async () => {
+      if (!event.projectId || !event.id) return;
+
+      try {
+        setIsLoading(true);
+        const response = await apiClient.get(`/projects/${event.projectId}/schedules/${event.id}`);
+        if (response.data && response.data.isSuccess) {
+          const data = response.data.data;
+          setDetailData((prev) => ({
+            ...prev,
+            text: data.title || prev.text,
+            content: data.content || prev.content,
+          }));
+        }
+      } catch (error) {
+        console.error('일정 상세 정보 조회 실패:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchEventDetail();
+  }, [event]);
+
+  if (!event || !detailData) return null;
 
   const formatEventDate = (date) => {
     if (!date) return '';
@@ -19,11 +54,11 @@ function EventDetailModal({ event, onClose }) {
     return `${year}.${month}.${day} (${weekday})`;
   };
 
-  const dateString = `${formatEventDate(event.start)} ~ ${formatEventDate(event.end)}`;
+  const dateString = `${formatEventDate(detailData.start)} ~ ${formatEventDate(detailData.end)}`;
 
   const handleProjectClick = () => {
-    if (event.projectId) {
-      navigate(`/project/${event.projectId}`, { state: { projectTitle: event.projectTitle } });
+    if (detailData.projectId) {
+      navigate(`/project/${detailData.projectId}`, { state: { projectTitle: detailData.projectTitle } });
       onClose();
     }
   };
@@ -38,17 +73,17 @@ function EventDetailModal({ event, onClose }) {
         </div>
         
         <div className="edm-body">
-          <h2 className="edm-title">{event.text}</h2>
+          <h2 className="edm-title">{detailData.text}</h2>
           
           <div className="edm-info">
-            {event.projectTitle && (
+            {detailData.projectTitle && (
               <div className="edm-info-row">
                 <span className="edm-info-label">프로젝트</span>
                 <span 
-                  className={`edm-info-value ${event.projectId ? 'edm-project-link' : ''}`}
-                  onClick={event.projectId ? handleProjectClick : undefined}
+                  className={`edm-info-value ${detailData.projectId ? 'edm-project-link' : ''}`}
+                  onClick={detailData.projectId ? handleProjectClick : undefined}
                 >
-                  {event.projectTitle}
+                  {detailData.projectTitle}
                 </span>
               </div>
             )}
@@ -60,7 +95,11 @@ function EventDetailModal({ event, onClose }) {
             <div className="edm-divider" />
             
             <div className="edm-content-wrapper">
-              <p className="edm-content">{event.content || '등록된 내용이 없습니다.'}</p>
+              {isLoading ? (
+                <p className="edm-content" style={{ color: '#909090' }}>내용을 불러오는 중입니다...</p>
+              ) : (
+                <p className="edm-content">{detailData.content || '등록된 내용이 없습니다.'}</p>
+              )}
             </div>
           </div>
         </div>

--- a/FE/src/components/NewTaskModal/NewTaskModal.jsx
+++ b/FE/src/components/NewTaskModal/NewTaskModal.jsx
@@ -1,43 +1,32 @@
 import React, { useState, useEffect } from 'react';
 import './NewTaskModal.css';
 
-const mockTeammates = [
-  { id: 1, name: '홍길동' },
-  { id: 2, name: '김철수' },
-  { id: 3, name: '이영희' },
-  { id: 4, name: '박민수' },
-];
-
-function NewTaskModal({ isOpen, onClose, onSubmit, projectId }) {
+function NewTaskModal({ isOpen, onClose, onSubmit, projectId, members = [] }) {
   const [title, setTitle] = useState('');
-  const [assigneeId, setAssigneeId] = useState('');
+  const [managerId, setManagerId] = useState('');
   const [description, setDescription] = useState('');
   const [dueDate, setDueDate] = useState('');
   
-  const [teammates, setTeammates] = useState([]);
-
   useEffect(() => {
-    if (isOpen) {
-      setTeammates(mockTeammates);
-    } else {
+    if (!isOpen) {
       setTitle('');
-      setAssigneeId('');
+      setManagerId('');
       setDescription('');
       setDueDate('');
     }
-  }, [isOpen, projectId]);
+  }, [isOpen]);
 
   if (!isOpen) return null;
 
   const handleSubmit = () => {
-    if (!title.trim() || !assigneeId || !dueDate) {
+    if (!title.trim() || !managerId || !dueDate) {
       alert('태스크 제목, 담당자, 마감일은 필수 입력 항목입니다.');
       return;
     }
 
     const newTask = {
       title,
-      assigneeId,
+      managerId,
       description,
       dueDate,
     };
@@ -67,12 +56,12 @@ function NewTaskModal({ isOpen, onClose, onSubmit, projectId }) {
             <label className="task-modal-label">담당자 <span style={{ color: '#E53E3E' }}>*</span></label>
             <select
               className="task-modal-select"
-              value={assigneeId}
-              onChange={(e) => setAssigneeId(e.target.value)}
+              value={managerId}
+              onChange={(e) => setManagerId(e.target.value)}
             >
               <option value="" disabled>담당자를 선택해주세요</option>
-              {teammates.map((member) => (
-                <option key={member.id} value={member.id}>
+              {members.map((member) => (
+                <option key={member.userId} value={member.userId}>
                   {member.name}
                 </option>
               ))}

--- a/FE/src/pages/TeamPage/TeamPage.jsx
+++ b/FE/src/pages/TeamPage/TeamPage.jsx
@@ -6,6 +6,9 @@ import ProgressBar from '../../components/ProgressBar/ProgressBar';
 import SummaryCard from '../../components/SummaryCard/SummaryCard';
 import moreIcon from '../../assets/moreIcon.svg';
 import NewTaskModal from '../../components/NewTaskModal/NewTaskModal.jsx';
+import PostModal from './components/PostModal.jsx';
+import PostDetailModal from './components/PostDetailModal.jsx';
+import TaskDetailModal from './components/TaskDetailModal.jsx';
 import { 
   getProjectMembers, 
   getProjectTasks, 
@@ -50,7 +53,6 @@ function TeamPage() {
   const [selectedPost, setSelectedPost] = useState(null);
   const [isDetailLoading, setIsDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState(null);
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const [isTaskExpanded, setIsTaskExpanded] = useState(false);
   const [isBoardExpanded, setIsBoardExpanded] = useState(false);
@@ -187,7 +189,6 @@ function TeamPage() {
     try {
       setIsDetailLoading(true);
       setDetailError(null);
-      setIsMenuOpen(false);
       setSelectedPost({ postId });
       const data = await getPostDetail(idToFetch, postId);
       setSelectedPost(data);
@@ -210,7 +211,6 @@ function TeamPage() {
     setIsEditMode(true);
     setPostTitle(selectedPost.title);
     setPostContent(selectedPost.content);
-    setIsMenuOpen(false);
     setIsPostModalOpen(true);
   };
 
@@ -278,7 +278,6 @@ function TeamPage() {
   const closePostDetailModal = () => {
     setSelectedPost(null);
     setDetailError(null);
-    setIsMenuOpen(false);
   };
 
   const formatDate = (dateString) => {
@@ -455,140 +454,37 @@ function TeamPage() {
         </section>
       </div>
 
-      {isPostModalOpen && (
-        <div className="team-post-modal-backdrop" role="presentation" onMouseDown={closePostModal}>
-          <div
-            className="team-post-modal"
-            role="dialog"
-            aria-modal="true"
-            onMouseDown={(event) => event.stopPropagation()}
-          >
-            <h2>{isEditMode ? '게시글 수정' : '게시글 쓰기'}</h2>
+      <PostModal
+        isOpen={isPostModalOpen}
+        isEditMode={isEditMode}
+        title={postTitle}
+        setTitle={setPostTitle}
+        content={postContent}
+        setContent={setPostContent}
+        onClose={closePostModal}
+        onSubmit={handlePostSubmit}
+        isSubmitting={isPostSubmitting}
+      />
 
-            <label className="team-post-field">
-              <span>제목</span>
-              <input
-                type="text"
-                value={postTitle}
-                onChange={(event) => setPostTitle(event.target.value)}
-                placeholder="제목을 적어주세요."
-                disabled={isPostSubmitting}
-              />
-            </label>
+      <PostDetailModal
+        isOpen={!!selectedPost}
+        post={selectedPost}
+        isLoading={isDetailLoading}
+        error={detailError}
+        onClose={closePostDetailModal}
+        onEdit={handleOpenEditModal}
+        onDelete={handleDeletePost}
+      />
 
-            <label className="team-post-field">
-              <span>내용</span>
-              <textarea
-                value={postContent}
-                onChange={(event) => setPostContent(event.target.value)}
-                placeholder="내용을 적어주세요."
-                disabled={isPostSubmitting}
-              />
-            </label>
-
-            <div className="team-post-modal-actions">
-              <button 
-                type="button" 
-                className="team-post-cancel-button" 
-                onClick={closePostModal}
-                disabled={isPostSubmitting}
-              >
-                취소
-              </button>
-              <button
-                type="button"
-                className="team-post-create-button"
-                onClick={handlePostSubmit}
-                disabled={!postTitle.trim() || !postContent.trim() || isPostSubmitting}
-              >
-                {isPostSubmitting ? '저장 중...' : isEditMode ? '수정 완료' : '게시글 생성'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {selectedPost && (
-        <div className="team-post-detail-backdrop" role="presentation" onMouseDown={closePostDetailModal}>
-          <article
-            className="team-post-detail-modal"
-            role="dialog"
-            aria-modal="true"
-            onMouseDown={(event) => event.stopPropagation()}
-          >
-            <div className="team-post-detail-menu-container" style={{ position: 'absolute', top: '20px', right: '20px' }}>
-              <button
-                type="button"
-                className="team-post-detail-menu"
-                aria-label="게시글 메뉴"
-                onClick={() => setIsMenuOpen((prev) => !prev)}
-              >
-                ...
-              </button>
-              {isMenuOpen && (
-                <div className="team-post-dropdown" style={{ position: 'absolute', right: 0, background: '#fff', border: '1px solid #ccc', borderRadius: '4px', zIndex: 10 }}>
-                  <button type="button" onClick={handleOpenEditModal} style={{ display: 'block', width: '100%', padding: '8px 16px', border: 'none', background: 'none', textAlign: 'left', cursor: 'pointer' }}>수정</button>
-                  <button type="button" onClick={handleDeletePost} style={{ display: 'block', width: '100%', padding: '8px 16px', border: 'none', background: 'none', textAlign: 'left', color: 'red', cursor: 'pointer' }}>삭제</button>
-                </div>
-              )}
-            </div>
-
-            {isDetailLoading && <div className="team-member-status">처리 중...</div>}
-            {detailError && <div className="team-member-status" style={{ color: 'red' }}>{detailError}</div>}
-
-            {!isDetailLoading && !detailError && selectedPost.title && (
-              <>
-                <h2 id="team-post-detail-title">{selectedPost.title}</h2>
-                <dl className="team-post-detail-meta">
-                  <dt>작성자</dt>
-                  <dd>{selectedPost.writerName}</dd>
-                </dl>
-                <p>{selectedPost.content}</p>
-              </>
-            )}
-          </article>
-        </div>
-      )}
-
-      {selectedTask && (
-        <div className="team-post-detail-backdrop" role="presentation" onMouseDown={() => setSelectedTask(null)}>
-          <article className="team-post-detail-modal" role="dialog" aria-modal="true" onMouseDown={(e) => e.stopPropagation()}>
-            {isTaskDetailLoading && <div className="team-member-status">태스크 정보 불러오는 중...</div>}
-            {taskDetailError && <div className="team-member-status" style={{ color: 'red' }}>{taskDetailError}</div>}
-            
-            {!isTaskDetailLoading && !taskDetailError && selectedTask.title && (
-              <>
-                <h2>{selectedTask.title}</h2>
-                <dl className="team-post-detail-meta" style={{ marginTop: '12px' }}>
-                  <dt>담당자</dt>
-                  <dd>{selectedTask.managerName} ({selectedTask.role || '역할 지정 없음'})</dd>
-                  <dt>마감일</dt>
-                  <dd>{selectedTask.dueDate}</dd>
-                  <dt>상태</dt>
-                  <dd>
-                    <select 
-                      value={selectedTask.status} 
-                      onChange={(e) => handleUpdateTaskStatus(selectedTask.taskId, selectedTask, e.target.value)}
-                      style={{ padding: '2px 6px', borderRadius: '4px', border: '1px solid #ccc' }}
-                    >
-                      <option value="TODO">TODO</option>
-                      <option value="IN_PROGRESS">IN_PROGRESS</option>
-                      <option value="DONE">DONE</option>
-                    </select>
-                  </dd>
-                </dl>
-                <div style={{ marginTop: '16px', borderTop: '1px solid #eee', paddingTop: '12px' }}>
-                  <p>{selectedTask.description || '상세 설명이 없습니다.'}</p>
-                </div>
-                <div className="team-post-modal-actions" style={{ marginTop: '24px', display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
-                  <button type="button" onClick={handleDeleteTask} style={{ padding: '8px 16px', border: 'none', background: '#ff4d4f', color: '#fff', borderRadius: '4px', cursor: 'pointer' }}>삭제</button>
-                  <button type="button" className="team-post-cancel-button" onClick={() => setSelectedTask(null)}>닫기</button>
-                </div>
-              </>
-            )}
-          </article>
-        </div>
-      )}
+      <TaskDetailModal
+        isOpen={!!selectedTask}
+        task={selectedTask}
+        isLoading={isTaskDetailLoading}
+        error={taskDetailError}
+        onClose={() => setSelectedTask(null)}
+        onStatusChange={handleUpdateTaskStatus}
+        onDelete={handleDeleteTask}
+      />
 
       <NewTaskModal
         isOpen={isNewTaskModalOpen}

--- a/FE/src/pages/TeamPage/TeamPage.jsx
+++ b/FE/src/pages/TeamPage/TeamPage.jsx
@@ -385,7 +385,7 @@ function TeamPage() {
         </div>
 
         <div className="team-calendar">
-          <Calendar />
+          <Calendar projectId={idToFetch} />
         </div>
 
         <section className="team-card team-members-card">

--- a/FE/src/pages/TeamPage/TeamPage.jsx
+++ b/FE/src/pages/TeamPage/TeamPage.jsx
@@ -595,6 +595,7 @@ function TeamPage() {
         onClose={() => setIsNewTaskModalOpen(false)}
         onSubmit={handleAddTaskSubmit}
         projectId={idToFetch}
+        members={members}
       />
     </div>
   );

--- a/FE/src/pages/TeamPage/TeamPage.jsx
+++ b/FE/src/pages/TeamPage/TeamPage.jsx
@@ -384,7 +384,7 @@ function TeamPage() {
         </div>
 
         <div className="team-calendar">
-          <Calendar projectId={idToFetch} />
+          <Calendar projectId={idToFetch} projectTitle={projectTitle} />
         </div>
 
         <section className="team-card team-members-card">

--- a/FE/src/pages/TeamPage/components/PostDetailModal.jsx
+++ b/FE/src/pages/TeamPage/components/PostDetailModal.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+
+function PostDetailModal({
+  isOpen,
+  post,
+  isLoading,
+  error,
+  onClose,
+  onEdit,
+  onDelete
+}) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  if (!isOpen || !post) return null;
+
+  return (
+    <div className="team-post-detail-backdrop" role="presentation" onMouseDown={onClose}>
+      <article
+        className="team-post-detail-modal"
+        role="dialog"
+        aria-modal="true"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="team-post-detail-menu-container" style={{ position: 'absolute', top: '20px', right: '20px' }}>
+          <button
+            type="button"
+            className="team-post-detail-menu"
+            aria-label="게시글 메뉴"
+            onClick={() => setIsMenuOpen((prev) => !prev)}
+          >
+            ...
+          </button>
+          {isMenuOpen && (
+            <div className="team-post-dropdown" style={{ position: 'absolute', right: 0, background: '#fff', border: '1px solid #ccc', borderRadius: '4px', zIndex: 10 }}>
+              <button type="button" onClick={() => { setIsMenuOpen(false); onEdit(); }} style={{ display: 'block', width: '100%', padding: '8px 16px', border: 'none', background: 'none', textAlign: 'left', cursor: 'pointer' }}>수정</button>
+              <button type="button" onClick={() => { setIsMenuOpen(false); onDelete(); }} style={{ display: 'block', width: '100%', padding: '8px 16px', border: 'none', background: 'none', textAlign: 'left', color: 'red', cursor: 'pointer' }}>삭제</button>
+            </div>
+          )}
+        </div>
+
+        {isLoading && <div className="team-member-status">처리 중...</div>}
+        {error && <div className="team-member-status" style={{ color: 'red' }}>{error}</div>}
+
+        {!isLoading && !error && post.title && (
+          <>
+            <h2 id="team-post-detail-title">{post.title}</h2>
+            <dl className="team-post-detail-meta">
+              <dt>작성자</dt>
+              <dd>{post.writerName}</dd>
+            </dl>
+            <p>{post.content}</p>
+          </>
+        )}
+      </article>
+    </div>
+  );
+}
+
+export default PostDetailModal;

--- a/FE/src/pages/TeamPage/components/PostModal.jsx
+++ b/FE/src/pages/TeamPage/components/PostModal.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+function PostModal({
+  isOpen,
+  isEditMode,
+  title,
+  setTitle,
+  content,
+  setContent,
+  onClose,
+  onSubmit,
+  isSubmitting
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="team-post-modal-backdrop" role="presentation" onMouseDown={onClose}>
+      <div
+        className="team-post-modal"
+        role="dialog"
+        aria-modal="true"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <h2>{isEditMode ? '게시글 수정' : '게시글 쓰기'}</h2>
+
+        <label className="team-post-field">
+          <span>제목</span>
+          <input
+            type="text"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="제목을 적어주세요."
+            disabled={isSubmitting}
+          />
+        </label>
+
+        <label className="team-post-field">
+          <span>내용</span>
+          <textarea
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+            placeholder="내용을 적어주세요."
+            disabled={isSubmitting}
+          />
+        </label>
+
+        <div className="team-post-modal-actions">
+          <button type="button" className="team-post-cancel-button" onClick={onClose} disabled={isSubmitting}>
+            취소
+          </button>
+          <button type="button" className="team-post-create-button" onClick={onSubmit} disabled={!(title || '').trim() || !(content || '').trim() || isSubmitting}>
+            {isSubmitting ? '저장 중...' : isEditMode ? '수정 완료' : '게시글 생성'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default PostModal;

--- a/FE/src/pages/TeamPage/components/TaskDetailModal.jsx
+++ b/FE/src/pages/TeamPage/components/TaskDetailModal.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+function TaskDetailModal({
+  isOpen,
+  task,
+  isLoading,
+  error,
+  onClose,
+  onStatusChange,
+  onDelete
+}) {
+  if (!isOpen || !task) return null;
+
+  return (
+    <div className="team-post-detail-backdrop" role="presentation" onMouseDown={onClose}>
+      <article className="team-post-detail-modal" role="dialog" aria-modal="true" onMouseDown={(e) => e.stopPropagation()}>
+        {isLoading && <div className="team-member-status">태스크 정보 불러오는 중...</div>}
+        {error && <div className="team-member-status" style={{ color: 'red' }}>{error}</div>}
+        
+        {!isLoading && !error && task.title && (
+          <>
+            <h2>{task.title}</h2>
+            <dl className="team-post-detail-meta" style={{ marginTop: '12px' }}>
+              <dt>담당자</dt>
+              <dd>{task.managerName} ({task.role || '역할 지정 없음'})</dd>
+              <dt>마감일</dt>
+              <dd>{task.dueDate}</dd>
+              <dt>상태</dt>
+              <dd>
+                <select value={task.status} onChange={(e) => onStatusChange(task.taskId, task, e.target.value)} style={{ padding: '2px 6px', borderRadius: '4px', border: '1px solid #ccc' }}>
+                  <option value="TODO">TODO</option>
+                  <option value="IN_PROGRESS">IN_PROGRESS</option>
+                  <option value="DONE">DONE</option>
+                </select>
+              </dd>
+            </dl>
+            <div style={{ marginTop: '16px', borderTop: '1px solid #eee', paddingTop: '12px' }}>
+              <p>{task.description || '상세 설명이 없습니다.'}</p>
+            </div>
+            <div className="team-post-modal-actions" style={{ marginTop: '24px', display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+              <button type="button" onClick={onDelete} style={{ padding: '8px 16px', border: 'none', background: '#ff4d4f', color: '#fff', borderRadius: '4px', cursor: 'pointer' }}>삭제</button>
+              <button type="button" className="team-post-cancel-button" onClick={onClose}>닫기</button>
+            </div>
+          </>
+        )}
+      </article>
+    </div>
+  );
+}
+
+export default TaskDetailModal;


### PR DESCRIPTION
## 📌 개요
팀 페이지에서 팀 일정 조회/추가/상세보기가 가능하도록 각각 API를 연동하고, 일정 및 태스크 추가 모달이 백엔드 명세에 맞게 동작하도록 수정했습니다.

## ⚙️ 작업 내용
- 팀 일정 조회 API 연동
- 팀 일정 추가 API 연동 
- 일정 추가 모달 UI 명세 반영
- 일정 날짜 처리 로직 수정
- 태스크 추가 모달 담당자 데이터 연동
- 일정 상세보기 모달창 구현
- 일정 상세보기 API 연동

### 일정 추가 모달 변경버전
<img width="400" alt="image" src="https://github.com/user-attachments/assets/81fea231-376c-41a4-8d5e-33f8e1c202a0" />


### 일정 상세보기 모달
<img width="800" alt="image" src="https://github.com/user-attachments/assets/64558fed-f5a4-48eb-a2c5-a07bfe6d31dc" />
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
