### PR TITLE
[fix] 자신이 쓴 모집글에 대해 지원 금지 로직

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/apply/service/ApplyService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/apply/service/ApplyService.java
@@ -95,6 +95,10 @@ public class ApplyService {
         Recruit recruit = recruitRepository.findById(recruitmentId)
                 .orElseThrow(() ->new GeneralException(RecruitErrorCode.RECRUITMENT_NOT_FOUND));
 
+        if (recruit.getUser().getId().equals(userId)) {
+            throw new GeneralException(RecruitErrorCode.SELF_APPLY_NOT_ALLOWED);
+        }
+
         validateRecruitingStatus(recruit);
 
         User user = userRepository.findById(userId)


### PR DESCRIPTION
SELF_APPLY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "RECRUIT_E007", "본인이 작성한 모집글에는 지원할 수 없습니다.")

모집글 지원 메서드에 방어 로직 추가
