### PR TITLE
[feat] 프로필 이미지 Base64 저장 기능 추가

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/user/dto/UserProfileUpdateRequestDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/dto/UserProfileUpdateRequestDTO.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserProfileUpdateRequestDTO {
     private String name;
+    private String profileImageBase64;
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/user/entity/User.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/entity/User.java
@@ -31,7 +31,7 @@ public class User extends BaseEntity {
     @Column(name="name", nullable = true)
     private String name;
 
-    @Column(name="profile_image_url", nullable = true)
+    @Column(name="profile_image_url", nullable = true, columnDefinition = "LONGTEXT")
     private String profileImageUrl;
 
     @Column(name="manner_temp", nullable = true)
@@ -68,8 +68,13 @@ public class User extends BaseEntity {
     @Builder.Default
     private List<UserProjectHistory> projectHistories = new ArrayList<>();
 
-    public void updateProfile(String name) {
-        this.name = name;
-        this.isProfileCompleted = true;
+    public void updateProfile(String name, String profileImageBase64
+    ) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (profileImageBase64 != null) {
+            this.profileImageUrl = profileImageBase64;
+        }
     }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/user/service/UserService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/user/service/UserService.java
@@ -37,7 +37,8 @@ public class UserService {
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         user.updateProfile(
-                request.getName()
+                request.getName(),
+                request.getProfileImageBase64()
         );
 
         return UserResponseDTO.from(user);


### PR DESCRIPTION
## 📌 개요
프로필 이미지를 Base64 형태로 수정하여 저장할 수 있도록 하였습니다.

## ⚙️ 작업 내용
- 프로필 이미지 수정 시 프론트에서 넘겨주는 base64 형태의 프로필 이미지를 받아 저장합니다.
 
## 🎸 기타사항
프론트 작업 시 바뀐 api 명세서 확인해주세요
