### PR TITLE
[fix] 내가 쓴 모집글 페이지 모집 중 글만 조회, 모집글 삭제 로직 세분화

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/controller/RecruitController.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/controller/RecruitController.java
@@ -122,14 +122,13 @@ public class RecruitController {
 
     @GetMapping("/me")
     public ApiResponse<RecruitPageResponse<MyRecruitResponse>> getMyRecruitments(
-            @AuthenticationPrincipal Long userId, 
-            @RequestParam(required = false) String status,
+            @AuthenticationPrincipal Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
 
-        RecruitPageResponse<MyRecruitResponse> response = recruitService.getMyRecruitments(userId, status, pageable);
+        RecruitPageResponse<MyRecruitResponse> response = recruitService.getMyRecruitments(userId,pageable);
 
         return ApiResponse.onSuccess(RecruitSuccessCode.RECRUITMENT_BOOKMARKED_LIST_FETCHED,response);
     }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/RecruitRepository.java
@@ -1,7 +1,6 @@
 package org.example.promate.domain.recruit.repository;
 
 import org.example.promate.domain.recruit.entity.Recruit;
-import org.example.promate.domain.recruit.enums.RecruitStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,11 +14,12 @@ import java.util.Optional;
 public interface RecruitRepository extends JpaRepository<Recruit, Long>, RecruitRepositoryCustom {
     Optional<Recruit> findByIdAndIsDeletedFalse(Long id);
 
-    @Query("SELECT r FROM Recruit r WHERE r.user.id = :userId " +
-            "AND (:status IS NULL OR r.status = :status)")
-    Page<Recruit> findByUserIdAndStatus(
+    @Query("SELECT r FROM Recruit r " +
+            "WHERE r.user.id = :userId " +
+            "AND r.isDeleted = false " +    //삭제되지 않은 게시글만 필터링
+       "AND r.status = 'RECRUITING'")       //모집 중인 게시글만 필터링
+    Page<Recruit> findActiveRecruitmentsByUserId(
             @Param("userId") Long userId,
-            @Param("status") RecruitStatus status,
             Pageable pageable
     );
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
@@ -150,8 +150,15 @@ public class RecruitService {
             throw new GeneralException(RecruitErrorCode.NOT_RECRUITMENT_AUTHOR);
         }
 
-        // 부모인 Recruit만 삭제하면 Project와 그 안의 Member들까지 DB에서 연쇄 삭제됨
-        recruit.delete();
+        if (recruit.getStatus() == RecruitStatus.RECRUITING) {
+            // CASE 1: 모집 중일 때는 Hard Delete
+            // -> cascade = CascadeType.ALL 설정에 의해 Project, Apply도 DB에서 통째로 지움
+            recruitRepository.delete(recruit);
+        } else {
+            // CASE 2: 이미 마감되었거나 진행 중일 때는 프로젝트 보호를 위해 겉만 숨김 (Soft Delete)
+            // -> 이래야 다른 팀원들이 프로젝트 내역에서 쫓겨나지 않음
+            recruit.delete(); // super.performDelete() 호출하여 is_deleted = true 변경
+        }
     }
 
 
@@ -302,19 +309,9 @@ public class RecruitService {
 
 
     //내가 생성한 모집글들 불러오기
-    public RecruitPageResponse<MyRecruitResponse> getMyRecruitments(Long userId, String status, Pageable pageable) {
-        RecruitStatus recruitStatus = null;
+    public RecruitPageResponse<MyRecruitResponse> getMyRecruitments(Long userId, Pageable pageable) {
 
-        // 쿼리 스트링으로 status가 넘어왔을 경우 대소문자 구분 없이 매핑 (null이면 전체 조회)
-        if (status != null && !status.isBlank()) {
-            try {
-                recruitStatus = RecruitStatus.valueOf(status.toUpperCase());
-            } catch (IllegalArgumentException e) {
-                throw new GeneralException(RecruitErrorCode.INVALID_RECRUIT_STATUS);
-            }
-        }
-
-        Page<Recruit> recruitPage = recruitRepository.findByUserIdAndStatus(userId, recruitStatus, pageable);
+        Page<Recruit> recruitPage = recruitRepository.findActiveRecruitmentsByUserId(userId,pageable);
 
         Page<MyRecruitResponse> mappedPage = recruitPage.map(MyRecruitResponse::from);
 


### PR DESCRIPTION
지원자 검토 페이지에 사용되는, 내가 쓴 모집글 모아보기에서 
모집 중인 글만 긁어오도록 변경.

모집글이 모집 중이면 hard delete + 연관 객체 전부 제거
모집 중이 아니라면 soft delete (연관 객체는 그대로 보호)
