### PR TITLE
[fix] 태스크 담당자 지정 로직 ID 식별자 통일

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/project/repository/MemberRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/repository/MemberRepository.java
@@ -19,7 +19,6 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     Optional<Member> findByProjectIdAndUserId(Long projectId, Long userId);
     boolean existsByUserIdAndProjectId(Long userId, Long projectId);
 
-    Optional<Member> findByIdAndProjectId(Long id,Long projectId);
     Optional<Member> findByUserIdAndProjectId(Long userId,Long projectId);
 
     List<Member> findByProjectId(Long projectId);

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/Task.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/entity/Task.java
@@ -46,13 +46,10 @@ public class Task extends BaseEntity {
     private Member member;
 
     // 데이터 수정
-    public void modify(TaskReqDto.ModifyTaskDto dto){
+    public void modify(TaskReqDto.ModifyTaskDto dto, Member member){
         this.title = dto.getTitle();
         this.description = dto.getDescription();
         this.dueDate = dto.getDueDate();
-    }
-
-    public void modify(Member member){
         this.member = member;
     }
 

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
@@ -18,13 +18,14 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     int countAllByProjectIdAndStatusAndIsDeletedFalse(Long projectId, TaskStatus status);
     int countAllByProjectIdAndStatusInAndIsDeletedFalse(Long projectId, List<TaskStatus> statuses);
 
-    // N+1 방지: Task를 가져올 때 Task의 Member, Project 정보도 한 번에 가져옴(삭제되지 않은 정보 대상)
+    // N+1 방지: Task를 가져올 때 Task의 Member, Project, User 정보도 한 번에 가져옴(삭제되지 않은 정보 대상)
     @Query("select t from Task t " +
             "join fetch t.member m " +
             "join fetch t.project p " +
+            "join fetch m.user u " +
             "where t.id = :taskId " +
             "and t.isDeleted = false")
-    Optional<Task> findByIdAndIsDeletedFalse(@Param("taskId")Long id);
+    Optional<Task> findByIdAndIsDeletedFalse(@Param("taskId") Long taskId);
 
 
     // dashboard에서 사용

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/service/command/TaskCommandServiceImpl.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/service/command/TaskCommandServiceImpl.java
@@ -31,8 +31,6 @@ public class TaskCommandServiceImpl implements TaskCommandService{
     private final TaskRepository taskRepository;
     private final TaskQueryService taskQueryService;
 
-    //TODO: 로그인 사용자 검증 부분 리팩토링 -> 중복 코드 많음
-
     // 태스크 추가하기
     @Override
     public TaskResDto.TaskInfoDto addTask(Long userId, Long projectId, TaskReqDto.AddTaskDto dto) {
@@ -45,8 +43,8 @@ public class TaskCommandServiceImpl implements TaskCommandService{
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ProjectException(ProjectErrorCode.ID_NOT_FOUND));
 
-        // 검증2: 담당자 ID가 프로젝트 멤버가 맞는지
-        Member member = memberRepository.findByIdAndProjectId(dto.getManagerId(), projectId)
+        // 검증2: 담당자 ID가 프로젝트 멤버가 맞는지(managerId는 userId)
+        Member member = memberRepository.findByUserIdAndProjectId(dto.getManagerId(), projectId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.TASK_FORBIDDEN_NOT_PROJECT_MEMBER));
 
 
@@ -63,34 +61,32 @@ public class TaskCommandServiceImpl implements TaskCommandService{
         Task task = taskRepository.findByIdAndIsDeletedFalse(taskId)
                 .orElseThrow(() -> new TaskException(TaskErrorCode.ID_NOT_FOUND));
 
-        // 로그인 사용자의 멤버 정보
         Member member = memberRepository.findByUserIdAndProjectId(userId, projectId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.TASK_FORBIDDEN_NOT_PROJECT_MEMBER));
 
         Member currentTaskManager = task.getMember();
 
-        // 검증1: 해당 프로젝트의 태스크인가
         if(!projectId.equals(task.getProject().getId())){
             throw new TaskException(TaskErrorCode.NOT_PROJECT_TASK);
         }
 
-        // 검증2: 수정 권한 검증. 팀장이나 태스크 담당 본인만 수정 가능
-        boolean isAssignee = currentTaskManager.equals(member);
+        boolean isAssignee = currentTaskManager.getId().equals(member.getId());
         boolean isLeader = member.getPosition() == Position.LEADER;
 
         if (!isAssignee && !isLeader) {
             throw new TaskException(TaskErrorCode.NOT_ASSIGNEE_OR_PROJECT_LEADER);
         }
 
-        // 태스크 수정
-        task.modify(dto);
-        // 태스크 담당자 변경
-        if(!currentTaskManager.getId().equals(dto.getManagerId())){
-            // 검증3: 변경할 태스크 담당자가 프로젝트의 멤버가 맞는가
-            Member newTaskManager = memberRepository.findByIdAndProjectId(dto.getManagerId(), projectId)
+        // 1. 담당자 변경 여부 체크 및 객체 확보
+        Member newTaskManager = currentTaskManager;
+        if (currentTaskManager.getUser() == null || !currentTaskManager.getUser().getId().equals(dto.getManagerId())) {
+            newTaskManager = memberRepository.findByUserIdAndProjectId(dto.getManagerId(), projectId)
                     .orElseThrow(() -> new MemberException(MemberErrorCode.TASK_FORBIDDEN_NOT_PROJECT_MEMBER));
-            task.modify(newTaskManager);
         }
+
+        // 2. 한 번에 수정 요청 (Task 엔티티 내부에서 dto와 manager를 한 번에 처리하도록 메서드를 만들면 베스트)
+        task.modify(dto, newTaskManager);
+
         taskRepository.saveAndFlush(task);
 
         return TaskConverter.toModifiedTaskInfoDto(task);
@@ -99,7 +95,6 @@ public class TaskCommandServiceImpl implements TaskCommandService{
     // 태스크 상태 변경 : TODO, IN_PROGRESS, DONE
     @Override
     public TaskResDto.UpdatedStatusTaskInfoDto updateTaskStatus(Long userId, Long projectId, Long taskId, TaskReqDto.UpdateTaskStatusDto dto) {
-        // 검증1: 로그인 사용자가 프로젝트 멤버인가
         if(!memberRepository.existsByUserIdAndProjectId(userId, projectId)){
             throw new MemberException(MemberErrorCode.TASK_FORBIDDEN_NOT_PROJECT_MEMBER);
         }
@@ -108,18 +103,13 @@ public class TaskCommandServiceImpl implements TaskCommandService{
                 .orElseThrow(() -> new TaskException(TaskErrorCode.ID_NOT_FOUND));
         Member assignee = task.getMember();
 
-        // 검증2: 상태 업데이트는 태스크 담당자 본인을 제외한 프로젝트 멤버만
-        if (assignee.getId().equals(userId)) {
+        if (assignee.getUser() != null && assignee.getUser().getId().equals(userId)) {
             throw new TaskException(TaskErrorCode.CANNOT_UPDATE_SELF_TASK);
         }
 
-        // 상태 업데이트
         task.updateStatus(dto.getStatus());
 
-        // 진행률
         double projectProgress = taskQueryService.calculateProjectProgress(projectId);
-
-        // 프로젝트 태스크 완료 여부
         boolean isProjectCompleted = (projectProgress == 100.0);
 
         return TaskConverter.toUpdatedStatusTaskInfoDto(task, projectProgress, isProjectCompleted);
@@ -130,14 +120,20 @@ public class TaskCommandServiceImpl implements TaskCommandService{
     public TaskResDto.DeletedTaskInfoDto deleteTask(Long userId, Long projectId, Long taskId) {
         Task task = taskRepository.findByIdAndIsDeletedFalse(taskId)
                 .orElseThrow(() -> new TaskException(TaskErrorCode.ID_NOT_FOUND));
+
+        // 해당 프로젝트의 태스크가 맞는가
+        if(!projectId.equals(task.getProject().getId())){
+            throw new TaskException(TaskErrorCode.NOT_PROJECT_TASK);
+        }
+
         Member currentTaskManager = task.getMember();
 
         // 로그인 사용자의 프로젝트 멤버 정보
         Member member = memberRepository.findByUserIdAndProjectId(userId, projectId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.TASK_FORBIDDEN_NOT_PROJECT_MEMBER));
 
-        // 검증: 태스크 삭제는 태스크 담당자 본인과 프로젝트 팀장만
-        boolean isAssignee = currentTaskManager.equals(member);
+        // 태스크 삭제는 태스크 담당자 본인과 프로젝트 팀장만
+        boolean isAssignee = currentTaskManager.getId().equals(member.getId());
         boolean isLeader = member.getPosition() == Position.LEADER;
         if(!isAssignee && !isLeader){
             throw new TaskException(TaskErrorCode.NOT_ASSIGNEE_OR_PROJECT_LEADER);


### PR DESCRIPTION
## 📌 개요
태스크 생성, 수정, 상태 변경, 삭제 시 발생하는 사용자 식별자(ID) 불일치 오류 해결

## ⚙️ 작업 내용
- **식별자 검증 로직 수정 (memberId ➡️ userId)**
  - 태스크 담당자 검증 시 Member 엔티티의 PK와 멤버 조회 API에서 반환되는 userId가 혼용되어 발생하던 검증 실패 버그를 userId 기준으로 일치시킴
  - 엔티티 객체 자체 비교 방식에서 확실한 ID 식별자 값 비교로 변경하여 불필요한 프록시 초기화 및 추가 쿼리 발생을 막음

## 🎸 기타사항