### PR TITLE
[fix] 팀페이지 게시글 수정 오류 및 모달 전환 UX 개선

### DIFF
--- a/FE/src/pages/TeamPage/TeamPage.jsx
+++ b/FE/src/pages/TeamPage/TeamPage.jsx
@@ -61,6 +61,7 @@ function TeamPage() {
   const [isEditMode, setIsEditMode] = useState(false);
   const [postTitle, setPostTitle] = useState('');
   const [postContent, setPostContent] = useState('');
+  const [editingPostId, setEditingPostId] = useState(null);
   const [isPostSubmitting, setIsPostSubmitting] = useState(false);
   const [isNewTaskModalOpen, setIsNewTaskModalOpen] = useState(false);
 
@@ -221,48 +222,59 @@ function TeamPage() {
     setIsPostModalOpen(true);
   };
 
-  const handleOpenEditModal = () => {
-    if (!selectedPost) return;
-    setIsEditMode(true);
-    setPostTitle(selectedPost.title);
-    setPostContent(selectedPost.content);
-    setIsPostModalOpen(true);
-  };
+const handleOpenEditModal = () => {
+  if (!selectedPost) return;
 
-  const handlePostSubmit = async () => {
-    if (!postTitle.trim() || !postContent.trim() || isPostSubmitting) {
-      return;
+  setIsEditMode(true);
+  setEditingPostId(selectedPost.postId);
+  setPostTitle(selectedPost.title);
+  setPostContent(selectedPost.content);
+  //수정 모달 열리면 기존 조회 모델 닫게 수정 완료(2026/06/02)
+  setSelectedPost(null);
+  setIsPostModalOpen(true);
+};
+
+const handlePostSubmit = async () => {
+  if (!postTitle.trim() || !postContent.trim() || isPostSubmitting) {
+    return;
+  }
+
+  try {
+    setIsPostSubmitting(true);
+
+    if (isEditMode) {
+      await updateProjectPost(idToFetch, editingPostId, {
+        title: postTitle.trim(),
+        content: postContent.trim(),
+        postType: selectedPost?.postType || "GENERAL",
+      });
+
+      setSelectedPost((prev) => ({
+        ...prev,
+        postId: editingPostId,
+        title: postTitle.trim(),
+        content: postContent.trim(),
+      }));
+    } else {
+      await createProjectPost(idToFetch, {
+        title: postTitle.trim(),
+        content: postContent.trim(),
+        postType: "GENERAL",
+      });
     }
 
-    try {
-      setIsPostSubmitting(true);
-      if (isEditMode) {
-        await updateProjectPost(idToFetch, selectedPost.postId, {
-          title: postTitle.trim(),
-          content: postContent.trim(),
-          postType: selectedPost.postType || 'GENERAL'
-        });
-        setSelectedPost((prev) => ({
-          ...prev,
-          title: postTitle.trim(),
-          content: postContent.trim()
-        }));
-      } else {
-        await createProjectPost(idToFetch, {
-          title: postTitle.trim(),
-          content: postContent.trim(),
-          postType: 'GENERAL'
-        });
-      }
-      closePostModal();
-      if (!isEditMode) closePostDetailModal();
-      await fetchPosts();
-    } catch (err) {
-      alert(`게시글 처리에 실패했습니다: ${err.message}`);
-    } finally {
-      setIsPostSubmitting(false);
-    }
-  };
+    closePostModal();
+    if (!isEditMode) closePostDetailModal();
+    await fetchPosts();
+  } catch (err) {
+    console.log("수정 에러:", err);
+    console.log("status:", err.response?.status);
+    console.log("data:", err.response?.data);
+    alert(`게시글 처리에 실패했습니다: ${err.message}`);
+  } finally {
+    setIsPostSubmitting(false);
+  }
+};
 
   const handleDeletePost = async () => {
     if (!selectedPost) return;
@@ -284,11 +296,12 @@ function TeamPage() {
     navigate(`/task-board?projectId=${idToFetch}&status=${status}`, { state: { projectTitle, dueDate: projectDueDate } });
   };
 
-  const closePostModal = () => {
-    setIsPostModalOpen(false);
-    setPostTitle('');
-    setPostContent('');
-  };
+const closePostModal = () => {
+  setIsPostModalOpen(false);
+  setPostTitle("");
+  setPostContent("");
+  setEditingPostId(null);
+};
 
   const closePostDetailModal = () => {
     setSelectedPost(null);


### PR DESCRIPTION

## 📌 개요
- 게시글 수정 기능에서 발생하던 ID 전달 오류를 해결하여 정상적으로 수정 요청이 처리되도록 개선했습니다.
- 게시글 수정 모달 진입 시 기존 조회 모달이 자동으로 닫히도록 UX를 개선하여 중복 모달 노출 문제를 해결했습니다.

## ⚙️ 작업 내용
- 기존에 게시글이 수정되지 않던 문제를 해결했습니다.
- electedPost에만 의존하지 않고 setEditingPostId를 별도로 관리하도록 개선하여, 수정 모달이 열린 이후에도 정확한 게시글 ID를 유지할 수 있도록 했습니다.
- 수정 모달이 열리면 기존 조회 모달이 닫기게 수정 완료했습니다.

 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
