### PR TITLE
[feat] 팀장 프로필 조회 수동 입력 프로젝트 이력 추가

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/PromateApplication.java
+++ b/BE/promate/src/main/java/org/example/promate/PromateApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
 //UserDetailsServiceAutoConfiguration은 Spring Boot가 자동으로 ID/PW 기반 로그인 시스템을 세팅하는 클래스입니다.

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitLeaderProfileResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitLeaderProfileResponse.java
@@ -36,8 +36,7 @@ public class RecruitLeaderProfileResponse {
         private LocalDate endDate;
         private String description;
         private String source; // "PROMATE" 또는 "MANUAL"
-        private Boolean editable;
-
+        
         private Double averageReviewScore;
         private Long reviewCount;
 

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitLeaderProfileResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitLeaderProfileResponse.java
@@ -26,6 +26,7 @@ public class RecruitLeaderProfileResponse {
     @Getter
     @Builder
     public static class ProjectHistoryDTO {
+        private Long historyId;
         private Long projectId;
         private String projectTitle;
         private String role;
@@ -33,6 +34,9 @@ public class RecruitLeaderProfileResponse {
         private ProjectStatus projectStatus;
         private LocalDate startDate;
         private LocalDate endDate;
+        private String description;
+        private String source; // "PROMATE" 또는 "MANUAL"
+        private Boolean editable;
 
         private Double averageReviewScore;
         private Long reviewCount;

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
@@ -23,6 +23,7 @@ import org.example.promate.domain.review.entity.MemberReview;
 import org.example.promate.domain.review.repository.MemberReviewRepository;
 import org.example.promate.domain.user.entity.User;
 import org.example.promate.domain.user.exception.UserErrorCode;
+import org.example.promate.domain.user.repository.UserProjectHistoryRepository;
 import org.example.promate.domain.user.repository.UserRepository;
 import org.example.promate.domain.recruit.code.RecruitErrorCode;
 import org.example.promate.domain.workspace.enums.TaskStatus;
@@ -51,6 +52,7 @@ public class RecruitService {
     private final BookmarkRepository bookmarkRepository;
     private final MemberReviewRepository memberReviewRepository;
     private final TaskRepository taskRepository;
+    private final UserProjectHistoryRepository userProjectHistoryRepository; // 팀장 수동입력 이력
 
     @Transactional
     public RecruitCreateResponse createRecruitment(
@@ -363,6 +365,7 @@ public class RecruitService {
                             );
 
                     return RecruitLeaderProfileResponse.ProjectHistoryDTO.builder()
+                            .historyId(null)
                             .projectId(project.getId())
                             .projectTitle(project.getTitle())
                             .role(member.getRole())
@@ -370,6 +373,8 @@ public class RecruitService {
                             .projectStatus(project.getStatus())
                             .startDate(project.getStartDate())
                             .endDate(project.getEndDate())
+                            .description(project.getDescription())
+                            .source("PROMATE")
                             .averageReviewScore(averageReviewScore)
                             .reviewCount((long) reviews.size())
                             .completedTaskCount(completedTaskCount)
@@ -377,6 +382,31 @@ public class RecruitService {
                             .build();
                 })
                 .toList();
+
+        List<RecruitLeaderProfileResponse.ProjectHistoryDTO> manualProjects =
+                userProjectHistoryRepository.findByUserId(leaderId)
+                        .stream()
+                        .map(history -> RecruitLeaderProfileResponse.ProjectHistoryDTO.builder()
+                                .historyId(history.getId())
+                                .projectId(null)
+                                .projectTitle(history.getProjectName())
+                                .role(history.getRole())
+                                .position(null)
+                                .projectStatus(null)
+                                .startDate(history.getStartDate())
+                                .endDate(history.getEndDate())
+                                .description(history.getDescription())
+                                .source("MANUAL")
+                                .averageReviewScore(0.0)
+                                .reviewCount(0L)
+                                .completedTaskCount(0)
+                                .incompleteTaskCount(0)
+                                .build())
+                        .toList();
+
+        List<RecruitLeaderProfileResponse.ProjectHistoryDTO> allProjects = new ArrayList<>();
+        allProjects.addAll(projects);
+        allProjects.addAll(manualProjects);
 
         Double totalAverageReviewScore =
                 memberReviewRepository.getGlobalAverageScoreByUserId(leaderId);
@@ -401,7 +431,9 @@ public class RecruitService {
                 .reviewCount(totalReviewCount)
                 .completedTaskCount(totalCompletedTaskCount)
                 .incompleteTaskCount(totalIncompleteTaskCount)
-                .projects(projects)
+                .projects(allProjects)
                 .build();
+
+
     }
 }


### PR DESCRIPTION
## 📌 개요
팀장 프로필 조회 수동 입력 프로젝트 이력 추가

## ⚙️ 작업 내용
- 팀장 프로필 조회 수동 입력 프로젝트 이력 추가
- 프로젝트 자동 종료 스케줄러 활성화(@EnableScheduling)
 
## 🎸 기타사항