### PR TITLE
[feat] 프로필 모달 - 프로젝트 클릭 시 해당 프로젝트 설명 페이지로 라우팅 설정

### DIFF
--- a/FE/src/components/ProfileModal/ProfileModal.jsx
+++ b/FE/src/components/ProfileModal/ProfileModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import "./ProfileModal.css";
 import closeIcon from "../../assets/icons/closeIcon.svg";
 import ProfileAvatar from "../ProfileAvatar/ProfileAvatar";
@@ -8,6 +9,7 @@ function ProfileModal({ isOpen, onClose, user, position }) {
   const [isDragging, setIsDragging] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const dragPos = useRef({ startX: 0, startY: 0, initialTop: 0, initialLeft: 0 });
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (position) {
@@ -68,6 +70,14 @@ function ProfileModal({ isOpen, onClose, user, position }) {
 
   const projects = user?.projects ?? [];
 
+  const handleProjectClick = (project) => {
+    const targetId = project.recruitmentId || project.id || project.projectId;
+    if (targetId) {
+      onClose();
+      navigate(`/readme/${targetId}`, { state: project });
+    }
+  };
+
   const popoverStyle = isMobile
     ? {
         position: "fixed",
@@ -126,7 +136,12 @@ function ProfileModal({ isOpen, onClose, user, position }) {
               const score = project.score || project.averageReviewScore;
 
               return (
-                <div className="profile-project-item" key={index}>
+                <div 
+                  className="profile-project-item" 
+                  key={index}
+                  onClick={() => handleProjectClick(project)}
+                  style={{ cursor: "pointer" }}
+                >
                   <div className="project-main-info">
                     <span className="project-title">{title}</span>
                     <span className="project-period">{period}</span>


### PR DESCRIPTION
## 📌 개요
프로필 모달에 있는 프로젝트 목록 클릭 시 해당 프로젝트 설명 페이지로 라우팅 설정했습니다.

## ⚙️ 작업 내용
- 프로필 모달 내 프로젝트 클릭 시 상세 페이지 이동 기능 추가
- 프로젝트 ID 조회 로직 추가
- 프로젝트 클릭 시 모달 자동 닫힘 처리
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
