### PR TITLE
[fix] 마감 임박 목록에 완료 태스크 필터링

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/dashboard/service/DashboardService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/dashboard/service/DashboardService.java
@@ -46,10 +46,11 @@ public class DashboardService {
         LocalDate sevenDaysLater = now.plusDays(7);
 
         return taskRepository
-                .findByMemberUserIdAndDueDateBetweenAndIsDeletedFalse(
+                .findByMemberUserIdAndDueDateBetweenAndIsDeletedFalseAndStatusNot(
                         userId,
                         now,
-                        sevenDaysLater
+                        sevenDaysLater,
+                        TaskStatus.DONE
                 )
                 .stream()
                 .map(this::toTaskDTO)

--- a/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/workspace/repository/TaskRepository.java
@@ -29,10 +29,11 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
 
     // dashboard에서 사용
-    List<Task> findByMemberUserIdAndDueDateBetweenAndIsDeletedFalse(
+    List<Task> findByMemberUserIdAndDueDateBetweenAndIsDeletedFalseAndStatusNot(
             Long userId,
             LocalDate startDate,
-            LocalDate endDate
+            LocalDate endDate,
+            TaskStatus status
     );
 
     List<Task> findByMemberUserIdAndStatusAndIsDeletedFalse(


### PR DESCRIPTION
## 📌 개요
마감 임박 태스크 조회 시 완료된 태스크가 조회되지 않도록 수정

## ⚙️ 작업 내용
- Repository 메서드에 AndStatusNot 조건 추가 (완료 상태 제외)
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
