### PR TITLE
[feat] 프로필 페이지 - 이름 수정 기능 구현

### DIFF
--- a/FE/src/pages/ProfilePage/ProfilePage.css
+++ b/FE/src/pages/ProfilePage/ProfilePage.css
@@ -103,6 +103,16 @@
   white-space: nowrap;
 }
 
+.edit-name-input {
+  font-family: "Pretendard", sans-serif;
+  font-size: 1.25rem;
+  font-weight: bold;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 4px 8px;
+  max-width: 150px;
+}
+
 .user-task-display {
   display: flex;
   flex-direction: column;

--- a/FE/src/pages/ProfilePage/ProfilePage.jsx
+++ b/FE/src/pages/ProfilePage/ProfilePage.jsx
@@ -9,6 +9,7 @@ import './ProfilePage.css';
 const ProfilePage = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [editName, setEditName] = useState('');
   const [editingProject, setEditingProject] = useState(null);
   const [profileImageUrl, setProfileImageUrl] = useState(null);
   const fileInputRef = useRef(null);
@@ -179,6 +180,20 @@ const ProfilePage = () => {
     }
   };
 
+  const handleEditComplete = async () => {
+    setIsEditing(false);
+    if (editName.trim() && editName !== userInfo.name) {
+      try {
+        const res = await apiClient.patch('/user/me', { name: editName.trim() });
+        const updatedName = res.data?.data?.name || editName.trim();
+        setUserInfo((prev) => ({ ...prev, name: updatedName }));
+      } catch (error) {
+        console.error('이름 수정 실패:', error);
+        alert('이름 수정에 실패했습니다.');
+      }
+    }
+  };
+
   return (
     <div className="page-wrapper">
       <h1 className="page-title">
@@ -210,7 +225,16 @@ const ProfilePage = () => {
               onChange={handleImageChange}
             />
             <div className="profile-name-block">
-              <h2 className="user-name-text">{userInfo.name}</h2>
+              {isEditing ? (
+                <input
+                  type="text"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  className="edit-name-input"
+                />
+              ) : (
+                <h2 className="user-name-text">{userInfo.name}</h2>
+              )}
             </div>
           </div>
           <div className="user-task-display">
@@ -286,10 +310,10 @@ const ProfilePage = () => {
           {isEditing ? (
             <>
               <button className="btn-edit-cancel" onClick={() => setIsEditing(false)}>취소</button>
-              <button className="btn-edit-complete" onClick={() => setIsEditing(false)}>완료</button>
+              <button className="btn-edit-complete" onClick={handleEditComplete}>완료</button>
             </>
           ) : (
-            <MainButton size="md" onClick={() => setIsEditing(true)}>수정하기</MainButton>
+            <MainButton size="md" onClick={() => { setIsEditing(true); setEditName(userInfo.name); }}>수정하기</MainButton>
           )}
         </div>
       </section>


### PR DESCRIPTION
## 📌 개요
프로필 페이지 수정하기 눌렀을 때 이름 수정 되도록 구현했습니다.

## ⚙️ 작업 내용
- 빈 칸이거나 이전 이름과 똑같으면 서버 요청이 가지 않도록 제한
- 수정 버튼 클릭 여부에 따라 이름 글자와 입력창이 바뀌어 보이도록 구현
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
