### PR TITLE
[fix] 공통 - 수동 생성한 프로젝트 이력 진행상태, 편집권한 필드 반영

### DIFF
--- a/FE/src/components/ProfileModal/ProfileModal.jsx
+++ b/FE/src/components/ProfileModal/ProfileModal.jsx
@@ -135,7 +135,9 @@ function ProfileModal({ isOpen, onClose, user, position }) {
             {projects.map((project, index) => {
               const title = project.title || project.projectTitle;
               const period = project.period || (project.startDate && project.endDate ? `${project.startDate} ~ ${project.endDate}` : "");
-              const status = project.status || (project.projectStatus === "DONE" ? "완료" : "진행중");
+              
+              const rawStatus = project.status || project.projectStatus;
+              const status = (rawStatus === "COMPLETED" || rawStatus === "DONE" || rawStatus === "완료") ? "완료" : "진행중";
               const score = project.score || project.averageReviewScore;
 
               return (

--- a/FE/src/pages/ProfilePage/ProfilePage.jsx
+++ b/FE/src/pages/ProfilePage/ProfilePage.jsx
@@ -91,8 +91,9 @@ const ProfilePage = () => {
         ...manualProjectsData.map((p) => ({
           ...p,
           title: p.projectName ?? p.title,
-          isCompleted: !!p.endDate,
+          isCompleted: p.status ? p.status === 'COMPLETED' : !!p.endDate,
           isManual: true,
+          isEditable: p.editable ?? true,
         })),
       ]);
     };
@@ -144,8 +145,9 @@ const ProfilePage = () => {
       setProjects((prev) => [...prev, {
         ...added,
         title: added.projectName ?? added.title,
-        isCompleted: !!added.endDate,
+        isCompleted: added.status ? added.status === 'COMPLETED' : !!added.endDate,
         isManual: true,
+        isEditable: added.editable ?? true,
       }]);
     } catch (error) {
       console.error('프로젝트 추가 중 오류 발생:', error);
@@ -159,7 +161,14 @@ const ProfilePage = () => {
       const updated = res.data.data;
       setProjects((prev) => prev.map((p) =>
         (p.historyId ?? p.id) === historyId
-          ? { ...p, ...updated, title: updated.projectName ?? updated.title, isCompleted: !!updated.endDate, isManual: true }
+          ? {
+              ...p,
+              ...updated,
+              title: updated.projectName ?? updated.title,
+              isCompleted: updated.status ? updated.status === 'COMPLETED' : !!updated.endDate,
+              isManual: true,
+              isEditable: updated.editable ?? true
+            }
           : p
       ));
     } catch (error) {
@@ -277,7 +286,7 @@ const ProfilePage = () => {
                           <span style={{ width: 47 }} />
                         )}
                       </div>
-                      {isEditing && proj.isManual && (
+                  {isEditing && proj.isManual && proj.isEditable && (
                         <>
                           <button
                             className="proj-delete-btn"


### PR DESCRIPTION
## 📌 개요
수동 생성한 프로젝트 이력 API 수정부분인 status와 editable 필드 프로필 페이지와 프로필 모달창에 반영했습니다.

## ⚙️ 작업 내용
- 프로필 페이지 수동 생성한 프로젝트 이력 진행상태, 편집권한 필드 반영
- 프로필 모달창 수동 생성한 프로젝트 이력 진행상태, 편집권한 필드 반영
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
