### PR TITLE
[feat] 지원자 검토 페이지 - 모집글 모집 수동 완료 API 연동

### DIFF
--- a/FE/src/components/ApplicantBox/ApplicantBox.jsx
+++ b/FE/src/components/ApplicantBox/ApplicantBox.jsx
@@ -13,6 +13,12 @@ function ApplicantBox({
   buttonColor = '#FE9A57',
   buttonTextColor = '#FFFFFF',
   onButtonClick,
+  secondaryButtonText,
+  secondaryButtonColor = '#D9D9D9',
+  secondaryButtonTextColor = '#FFFFFF',
+  onSecondaryButtonClick,
+  showSecondaryButton = false,
+  disableSecondaryButton = false,
   showBookmark = true,
   isBookmarked = false,
   onBookmarkClick,
@@ -51,6 +57,20 @@ function ApplicantBox({
               aria-label={isBookmarked ? "즐겨찾기 해제" : "즐겨찾기 추가"}
             >
               <img src={isBookmarked ? bookmarkOrange : bookmarkGray} alt="bookmark icon" />
+            </button>
+          )}
+          {showSecondaryButton && (
+            <button
+              type="button"
+              className={`applicant-action-btn ${secondaryButtonColor === '#FE9A57' && !disableSecondaryButton ? 'hover-active' : ''}`}
+              style={{ backgroundColor: secondaryButtonColor, color: secondaryButtonTextColor, cursor: disableSecondaryButton ? 'default' : 'pointer' }}
+              onClick={(e) => {
+                if (onClick) e.stopPropagation();
+                if (onSecondaryButtonClick) onSecondaryButtonClick(e);
+              }}
+              disabled={disableSecondaryButton}
+            >
+              {secondaryButtonText}
             </button>
           )}
           <button

--- a/FE/src/pages/ApplicantPage/ApplicantList.jsx
+++ b/FE/src/pages/ApplicantPage/ApplicantList.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import ApplicantBox from '../../components/ApplicantBox/ApplicantBox';
 import Pagination from '../../components/Pagination/Pagination';
 import { getMyRecruitments } from '../../api/RecruitApi';
+import apiClient from '../../api/apiClient';
 import './ApplicantPage.css';
 
 const CATEGORY_LABEL = {
@@ -21,14 +22,7 @@ const ApplicantList = () => {
   const [loading, setLoading] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
 
-  useEffect(() => {
-    const token = localStorage.getItem('accessToken');
-    if (!token) {
-      alert('로그인이 필요한 서비스입니다.');
-      navigate(-1);
-      return;
-    }
-
+  const fetchRecruitments = () => {
     setLoading(true);
     getMyRecruitments()
       .then((res) => {
@@ -37,7 +31,35 @@ const ApplicantList = () => {
       })
       .catch((err) => console.error('모집글 목록 조회 실패', err))
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    const token = localStorage.getItem('accessToken');
+    if (!token) {
+      alert('로그인이 필요한 서비스입니다.');
+      navigate(-1);
+      return;
+    }
+
+    fetchRecruitments();
   }, [navigate]);
+
+  const handleCompleteRecruitment = async (recruitmentId) => {
+    if (!window.confirm('모집을 수동으로 완료하시겠습니까?\n(완료 시 프로젝트가 생성 및 시작됩니다.)')) return;
+
+    try {
+      const res = await apiClient.patch(`/recruitments/${recruitmentId}/status`, {
+        status: 'COMPLETED'
+      });
+      if (res.data?.isSuccess) {
+        alert(res.data.message || '모집이 완료되었으며, 프로젝트 팀이 생성되었습니다.');
+        fetchRecruitments();
+      }
+    } catch (err) {
+      console.error('모집 수동 완료 실패:', err);
+      alert(err.message || '모집 완료 처리에 실패했습니다.');
+    }
+  };
 
   const totalPages = Math.ceil(recruitments.length / ITEMS_PER_PAGE);
   const currentRecruitments = recruitments.slice(
@@ -62,6 +84,10 @@ const ApplicantList = () => {
               summary={CATEGORY_LABEL[recruitment.category] ?? recruitment.category}
               capacity={recruitment.maxMember}
               showBookmark={false}
+              showSecondaryButton={!isClosed}
+              secondaryButtonText="모집 수동 완료"
+              secondaryButtonColor="#D9D9D9"
+              onSecondaryButtonClick={() => handleCompleteRecruitment(targetId)}
               buttonText={isClosed ? '모집 마감' : '지원자 검토'}
               buttonColor={isClosed ? '#D9D9D9' : '#FE9A57'}
               disabled={isClosed}


### PR DESCRIPTION
## 📌 개요
지원자 검토 페이지에 모집글 모집 수동 완료 API 연동했습니다.

## ⚙️ 작업 내용
- ApplicantBox 속성 추가
- 상태 변경 API 호출
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
