### PR TITLE
[style] 팀 페이지 - 컴포넌트 배치와 크기 조정

### DIFF
--- a/FE/src/pages/TeamPage/TeamPage.css
+++ b/FE/src/pages/TeamPage/TeamPage.css
@@ -224,7 +224,7 @@
 }
 
 .team-members-card {
-  grid-row: 4;
+  grid-row: 5;
   align-self: start;
   min-height: 125px;
   height: auto;
@@ -232,7 +232,7 @@
 }
 
 .team-board-card {
-  grid-row: 5;
+  grid-row: 4;
   align-self: start;
   min-height: 190px;
   padding: 22px 32px 12px;

--- a/FE/src/pages/TeamPage/TeamPage.css
+++ b/FE/src/pages/TeamPage/TeamPage.css
@@ -217,61 +217,6 @@
   min-height: 0;
 }
 
-.team-calendar .calendar-section {
-  min-height: 300px;
-  padding: 22px 34px 24px;
-  border-radius: 8px;
-}
-
-.team-calendar .calendar-title {
-  font-size: 18px;
-  font-weight: 600;
-}
-
-.team-calendar .nav-date {
-  font-size: 14px;
-}
-
-.team-calendar .calendar-body {
-  padding: 12px 0 0;
-}
-
-.team-calendar .calendar-grid {
-  grid-auto-rows: minmax(44px, 1fr);
-}
-
-.team-calendar .weekday {
-  font-size: 10px;
-}
-
-.team-calendar .calendar-cell {
-  min-height: 44px;
-}
-
-.team-calendar .day-number {
-  font-size: 11px;
-}
-
-.team-calendar .calendar-sidebar {
-  width: 132px;
-}
-
-.team-calendar .calendar-todo-list {
-  padding: 0;
-}
-
-.team-calendar .todo-item {
-  min-height: 24px;
-}
-
-.team-calendar .todo-text {
-  font-size: 11px;
-}
-
-.team-calendar .add-event-btn {
-  font-size: 12px;
-}
-
 .team-members-card,
 .team-board-card {
   grid-column: 3;
@@ -899,14 +844,6 @@
   
   .team-board-list {
     margin: 0;
-  }
-  
-  .team-calendar .calendar-body {
-    flex-direction: column;
-  }
-
-  .team-calendar .calendar-sidebar {
-    width: 100%;
   }
 
   .team-post-modal-backdrop {

--- a/FE/src/pages/TeamPage/TeamPage.css
+++ b/FE/src/pages/TeamPage/TeamPage.css
@@ -533,7 +533,8 @@
   z-index: 1000;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
+  overflow-y: auto;
 }
 
 .team-detail-container {
@@ -543,7 +544,9 @@
   padding: 0px 47px 30px;
   gap: 16px;
   width: 500px;
-  height: 350px;
+  min-height: 350px;
+  height: auto;
+  margin: 40px auto;
   box-sizing: border-box;
   background: #FFFFFF;
   box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.05);
@@ -686,7 +689,6 @@
   gap: 20px;
   width: 100%;
   flex: 1;
-  overflow: hidden;
   max-width: 580px;
 }
 
@@ -794,7 +796,6 @@
   gap: 10px;
   width: 100%;
   flex: 1;
-  overflow-y: auto;
 }
 
 .team-detail-content {

--- a/FE/src/pages/TeamPage/TeamPage.css
+++ b/FE/src/pages/TeamPage/TeamPage.css
@@ -320,6 +320,9 @@
   font-weight: 600;
   color: #000000;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .team-member span,
@@ -328,6 +331,7 @@
   font-size: 12px;
   color: #909090;
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .team-board-list {

--- a/FE/src/pages/TeamPage/TeamPage.css
+++ b/FE/src/pages/TeamPage/TeamPage.css
@@ -25,10 +25,6 @@
   max-width: 1360px;
 }
 
-.team-page-grid.team-task-expanded {
-  grid-template-rows: 86px 58px minmax(340px, auto) auto minmax(190px, 1fr);
-}
-
 .team-card {
   background: #ffffff;
   border-radius: 8px;
@@ -108,11 +104,6 @@
   flex-direction: column;
   padding: 13px 30px 20px;
   min-height: 222px;
-  transition: min-height 0.2s ease;
-}
-
-.team-task-board.team-card-expanded {
-  min-height: 504px;
 }
 
 .team-task-list {
@@ -238,10 +229,6 @@
   padding: 22px 32px 12px;
   display: flex;
   flex-direction: column;
-}
-
-.team-board-card.team-card-expanded {
-  min-height: 270px;
 }
 
 .team-board-header {

--- a/FE/src/pages/TeamPage/TeamPage.jsx
+++ b/FE/src/pages/TeamPage/TeamPage.jsx
@@ -432,25 +432,6 @@ const closePostModal = () => {
           <Calendar projectId={idToFetch} projectTitle={projectTitle} />
         </div>
 
-        <section className="team-card team-members-card">
-          <PanelTitle icon={<Users size={18} />} title="프로젝트 팀원" />
-          <div className="team-members-list">
-            {isMembersLoading && <div className="team-member-status">불러오는 중...</div>}
-            {membersError && <div className="team-member-status" style={{ color: 'red' }}>{membersError}</div>}
-            
-            {!isMembersLoading && !membersError && members.length === 0 && (
-              <div className="team-member-status">참여 중인 팀원이 없습니다.</div>
-            )}
-
-            {!isMembersLoading && !membersError && members.map((member) => (
-              <div className="team-member" key={member.userId}>
-                <strong>{member.name}</strong>
-                <span>{member.role || '팀원'}</span>
-              </div>
-            ))}
-          </div>
-        </section>
-
         <section className={`team-card team-board-card ${isBoardExpanded ? 'team-card-expanded' : ''}`}>
           <div className="team-board-header">
             <PanelTitle icon={<ClipboardList size={18} />} title="게시판" />
@@ -496,6 +477,25 @@ const closePostModal = () => {
               onClick={() => setIsBoardExpanded((expanded) => !expanded)}
             />
           )}
+        </section>
+
+        <section className="team-card team-members-card">
+          <PanelTitle icon={<Users size={18} />} title="프로젝트 팀원" />
+          <div className="team-members-list">
+            {isMembersLoading && <div className="team-member-status">불러오는 중...</div>}
+            {membersError && <div className="team-member-status" style={{ color: 'red' }}>{membersError}</div>}
+            
+            {!isMembersLoading && !membersError && members.length === 0 && (
+              <div className="team-member-status">참여 중인 팀원이 없습니다.</div>
+            )}
+
+            {!isMembersLoading && !membersError && members.map((member) => (
+              <div className="team-member" key={member.userId}>
+                <strong>{member.name}</strong>
+                <span>{member.role || '팀원'}</span>
+              </div>
+            ))}
+          </div>
         </section>
       </div>
 


### PR DESCRIPTION
## 📌 개요
팀페이지 컴포넌트의 배치와 크기를 직관적으로 조정하고 세부적인 UI 오류를 수정했습니다.

## ⚙️ 작업 내용
- 캘린더 크기 수정
- 게시판 카드와 프로젝트 팀원 카드의 배치 위치 변경
- 태스크보드 카드의 고정 길이 제거
- 게시글 상세보기 모달창의 불필요한 스크롤 제거
- 게시판 제목이 길어질 때 UI 레이아웃이 깨지는 현상 방지
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
