### PR TITLE
[style] 팀 페이지 - 캘린더 너비 수정 및 반응형 가로 스크롤 제거 

### DIFF
--- a/FE/src/pages/TeamPage/TeamPage.css
+++ b/FE/src/pages/TeamPage/TeamPage.css
@@ -18,11 +18,12 @@
 
 .team-page-grid {
   display: grid;
-  grid-template-columns: minmax(280px, 430px) minmax(360px, 1fr) minmax(260px, calc((100% - 20px) / 2.6));
+  grid-template-columns: minmax(280px, 3fr) minmax(360px, 5fr) minmax(260px, 5fr);
   grid-template-rows: 86px 58px minmax(58px, auto) auto minmax(190px, 1fr);
   gap: 10px 20px;
   width: 100%;
   max-width: 1450px;
+  box-sizing: border-box;
 }
 
 .team-card {

--- a/FE/src/pages/TeamPage/TeamPage.css
+++ b/FE/src/pages/TeamPage/TeamPage.css
@@ -18,11 +18,11 @@
 
 .team-page-grid {
   display: grid;
-  grid-template-columns: minmax(280px, 430px) minmax(360px, 1fr) minmax(260px, 320px);
+  grid-template-columns: minmax(280px, 430px) minmax(360px, 1fr) minmax(260px, calc((100% - 20px) / 2.6));
   grid-template-rows: 86px 58px minmax(58px, auto) auto minmax(190px, 1fr);
-  gap: 10px 16px;
+  gap: 10px 20px;
   width: 100%;
-  max-width: 1360px;
+  max-width: 1450px;
 }
 
 .team-card {


### PR DESCRIPTION
## 📌 개요
팀 페이지 캘린더 너비를 줄이고 반응형에서 불필요한 가로스크롤 뜨는 걸 제거했습니다.

## ⚙️ 작업 내용
- 캘린더 비율 조절
- 반응형 비율 깨짐 방지
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
