### PR TITLE
[fix] 북마크 상태 불일치 오류 수정

### DIFF
--- a/BE/promate/src/main/java/org/example/promate/domain/project/dto/MyActivityResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/dto/MyActivityResponseDTO.java
@@ -14,4 +14,5 @@ public class MyActivityResponseDTO {
     private String description; // 프로젝트 설명
     private LocalDate startDate;
     private LocalDate endDate;
+    private boolean isBookmarked;
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/project/dto/MyApplicationResponseDTO.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/dto/MyApplicationResponseDTO.java
@@ -16,4 +16,5 @@ public class MyApplicationResponseDTO {
     private LocalDateTime createdAt;
     private String description; // 프로젝트 설명
     private Integer recruitCount; // 모집인원 반환
+    private boolean isBookmarked;
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/project/service/ProjectService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/project/service/ProjectService.java
@@ -1,6 +1,7 @@
 package org.example.promate.domain.project.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.promate.domain.apply.entity.Apply;
 import org.example.promate.domain.apply.repository.ApplyRepository;
 import org.example.promate.domain.project.code.MemberErrorCode;
 import org.example.promate.domain.project.code.ProjectErrorCode;
@@ -8,12 +9,14 @@ import org.example.promate.domain.project.dto.MyActivityResponseDTO;
 import org.example.promate.domain.project.dto.MyApplicationResponseDTO;
 import org.example.promate.domain.project.dto.MyProjectResponseDTO;
 import org.example.promate.domain.project.dto.ProjectMemberResponseDTO;
+import org.example.promate.domain.project.entity.Member;
 import org.example.promate.domain.project.entity.Project;
 import org.example.promate.domain.project.enums.ProjectStatus;
 import org.example.promate.domain.project.exception.MemberException;
 import org.example.promate.domain.project.exception.ProjectException;
 import org.example.promate.domain.project.repository.MemberRepository;
 import org.example.promate.domain.project.repository.ProjectRepository;
+import org.example.promate.domain.recruit.repository.BookmarkRepository;
 import org.example.promate.domain.recruit.repository.RecruitRepository;
 import org.example.promate.domain.review.entity.MemberReview;
 import org.example.promate.domain.review.repository.MemberReviewRepository;
@@ -24,6 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.IntStream;
 
 @Service
@@ -37,12 +41,18 @@ public class ProjectService {
     private final MemberRepository memberRepository;
     private final TaskRepository taskRepository;
     private final MemberReviewRepository memberReviewRepository;
-
+    private final BookmarkRepository bookmarkRepository;
 
     @Transactional(readOnly = true)
     public List<MyApplicationResponseDTO> getMyApplications(Long userId) {
-        return applyRepository.findByUserIdWithRecruit(userId)
-                .stream()
+        // 지원서 목록 조회
+        List<Apply> myApplies = applyRepository.findByUserIdWithRecruit(userId);
+
+        // 북마크 여부 조회
+        List<Long> recruitIds = myApplies.stream().map(apply -> apply.getRecruit().getId()).toList();
+        Set<Long> bookmarkedRecruitIds = bookmarkRepository.findBookmarkedRecruitIds(userId, recruitIds);
+
+        return myApplies.stream()
                 .map(apply -> MyApplicationResponseDTO.builder()
                         .applicationId(apply.getId())
                         .recruitmentId(apply.getRecruit().getId())
@@ -51,6 +61,7 @@ public class ProjectService {
                         .recruitCount(apply.getRecruit().getTotalSlots())
                         .status(apply.getStatus())
                         .createdAt(apply.getCreatedAt())
+                        .isBookmarked(bookmarkedRecruitIds.contains(apply.getRecruit().getId()))
                         .build())
                 .toList();
     }
@@ -114,7 +125,14 @@ public class ProjectService {
 
     @Transactional(readOnly = true)
     public List<MyActivityResponseDTO> getMyActivities(Long userId) {
+        // 멤버 활동 목록 조회
+        List<Member> myMembers = memberRepository.findByUserIdAndProjectStatus(userId, ProjectStatus.COMPLETED);
 
+        // 프로젝트의 모집글에 대한 북마크 여부 판단
+        List<Long> recruitIds = myMembers.stream()
+                .map(member -> member.getProject().getRecruit().getId()) // 프로젝트로 모집글 ID 추출
+                .toList();
+        Set<Long> bookmarkedRecruitIds = bookmarkRepository.findBookmarkedRecruitIds(userId, recruitIds);
 
         return memberRepository
                 .findByUserIdAndProjectStatus(userId, ProjectStatus.COMPLETED)
@@ -132,6 +150,7 @@ public class ProjectService {
                             .startDate(member.getProject().getStartDate())
                             .endDate(member.getProject().getEndDate())
                             .averageReviewScore(averageReviewScore)
+                            .isBookmarked(bookmarkedRecruitIds.contains(member.getProject().getRecruit().getId()))
                             .build();
                 })
                 .toList();

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/MyRecruitResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/MyRecruitResponse.java
@@ -12,9 +12,10 @@ public record MyRecruitResponse(
         LocalDateTime createdAt,
         RecruitStatus status,
         int currentMember,
-        int maxMember
+        int maxMember,
+        boolean isBookmarked
 ) {
-    public static MyRecruitResponse from(Recruit recruit) {
+    public static MyRecruitResponse from(Recruit recruit, boolean isBookmarked) {
         return new MyRecruitResponse(
                 recruit.getId(),
                 recruit.getTitle(),
@@ -22,7 +23,8 @@ public record MyRecruitResponse(
                 recruit.getCreatedAt(),
                 recruit.getStatus(),
                 recruit.getJoinedCount(),
-                recruit.getTotalSlots()
+                recruit.getTotalSlots(),
+                isBookmarked
         );
     }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitResponse.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/dto/response/RecruitResponse.java
@@ -19,9 +19,10 @@ public record RecruitResponse(
         int currentMember,
         Long projectId,         // 모집글을 통해 개설된 프로젝트 ID (개설 전이면 null)
         Status myApplyStatus,   // 본인의 지원 상태 (PENDING, ACCEPTED, REJECTED / 지원 안 했으면 null)
-        Long myApplicationId    // 본인의 지원서 ID (지원 안 했으면 null)
+        Long myApplicationId,    // 본인의 지원서 ID (지원 안 했으면 null)
+        boolean isBookmarked    //사용자의 북마크 여부
 ) {
-    public static RecruitResponse of(Recruit recruit, Status myApplyStatus, Long myApplicationId, Long userId) {
+    public static RecruitResponse of(Recruit recruit, Status myApplyStatus, Long myApplicationId, Long userId, boolean isBookmarked) {
 
         Long targetProjectId = null;
 
@@ -48,7 +49,8 @@ public record RecruitResponse(
                 // Project 엔티티 연관관계가 있다면 ID 추출, 없으면 null
                 targetProjectId,
                 myApplyStatus,
-                myApplicationId
+                myApplicationId,
+                isBookmarked
         );
     }
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/BookmarkRepository.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/repository/BookmarkRepository.java
@@ -9,7 +9,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark,Long> {
     Optional<Bookmark> findByUserAndRecruit(User user, Recruit recruit);
@@ -17,4 +19,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark,Long> {
     @Query(value = "select b from Bookmark b join fetch b.recruit where b.user.id = :userId",
             countQuery = "select count(b) from Bookmark b where b.user.id = :userId")
     Page<Bookmark> findByUserIdWithRecruit(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("SELECT b.recruit.id FROM Bookmark b WHERE b.user.id = :userId AND b.recruit.id IN :recruitIds")
+    Set<Long> findBookmarkedRecruitIds(@Param("userId") Long userId, @Param("recruitIds") List<Long> recruitIds);
 }

--- a/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
+++ b/BE/promate/src/main/java/org/example/promate/domain/recruit/service/RecruitService.java
@@ -270,6 +270,7 @@ public class RecruitService {
         if (recruits.isEmpty()) return Collections.emptyList();
 
         Map<Long, Apply> applyMap = new HashMap<>();
+        Set<Long> bookmarkedRecruitIds = new HashSet<>();   // 북마크된 모집글 담을 hashSet
 
         // 로그인한 유저인 경우에만 쿼리로 지원서들을 한 번에 싹 긁어옴
         if (userId != null) {
@@ -277,18 +278,25 @@ public class RecruitService {
             List<Apply> myApplies = applyRepository.findByUserIdAndRecruitIdIn(userId, recruitIds);
             applyMap = myApplies.stream()
                     .collect(Collectors.toMap(apply -> apply.getRecruit().getId(), apply -> apply));
+
+            bookmarkedRecruitIds = bookmarkRepository.findBookmarkedRecruitIds(userId, recruitIds);
         }
 
         Map<Long, Apply> finalApplyMap = applyMap;
+        Set<Long> finalBookmarkedRecruitIds = bookmarkedRecruitIds;
 
         return recruits.stream().map(recruit -> {
             Apply myApply = finalApplyMap.get(recruit.getId());
+
+            // 현재 모집글이 북마크 되어 있다면 true, 아니면 false
+            boolean isBookmarked = finalBookmarkedRecruitIds.contains(recruit.getId());
 
             return RecruitResponse.of(
                     recruit,
                     myApply != null ? myApply.getStatus() : null,
                     myApply != null ? myApply.getId() : null,
-                    userId
+                    userId,
+                    isBookmarked
             );
         }).toList();
     }
@@ -315,7 +323,13 @@ public class RecruitService {
 
         Page<Recruit> recruitPage = recruitRepository.findActiveRecruitmentsByUserId(userId,pageable);
 
-        Page<MyRecruitResponse> mappedPage = recruitPage.map(MyRecruitResponse::from);
+        // 북마크된 모집글 불러오기
+        List<Long> recruitIds = recruitPage.getContent().stream().map(Recruit::getId).toList();
+        Set<Long> bookmarkedRecruitIds = bookmarkRepository.findBookmarkedRecruitIds(userId, recruitIds);
+
+        Page<MyRecruitResponse> mappedPage = recruitPage.map(recruit ->
+                MyRecruitResponse.from(recruit, bookmarkedRecruitIds.contains(recruit.getId()))
+        );
 
         return RecruitPageResponse.of(mappedPage);
     }


### PR DESCRIPTION
## 📌 개요
여러 탭(북마크, 지원 현황, 생성글 등) 간에 모집글 북마크 아이콘 상태가 동기화되지 않는 버그 수정

## ⚙️ 작업 내용
- `RecruitResponse`, `MyRecruitResponse `등 모든 관련 DTO에 `isBookmarked` 필드 추가
- 각 탭의 목록 조회 서비스 로직에 로그인 유저의 북마크 데이터 결합 처리
 
## 🎸 기타사항
필요한 경우 자유롭게 추가 작성 (참고 링크, 주의사항 등)
